### PR TITLE
Issue/59 modifier keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The following lists show the changes to the library grouped by domain.
 
 #### Keyboard support
 
-* changing [`ally.when.key`][ally/when/key] to handle modifier keys - [issue #59](https://github.com/medialize/ally.js/issues/59)
+* changing [`ally.when.key`][ally/when/key] to handle modifier keys and respect `context` and `filter` options - [issue #59](https://github.com/medialize/ally.js/issues/59)
 * changing [`ally.map.keycode`][ally/map/keycode] to provide alphanumeric keys and aliasing
 
 #### Internals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The following lists show the changes to the library grouped by domain.
 #### Keyboard support
 
 * changing [`ally.when.key`][ally/when/key] to handle modifier keys - [issue #59](https://github.com/medialize/ally.js/issues/59)
+* changing [`ally.map.keycode`][ally/map/keycode] to provide alphanumeric keys and aliasing
 
 #### Internals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,14 @@ The following lists show the changes to the library grouped by domain.
 
 * changing [`ally.is.focusRelevant`][ally/is/focus-relevant] and [`ally.is.focusable`][ally/is/focusable] to regard `<keygen>` and `<embed>` focus-relevant but *not* focusable - [issue #82](https://github.com/medialize/ally.js/issues/82)
 * changing [`ally.is.validArea`][ally/is/valid-area] to properly handle `<area href="…">` vs. `<area>` - [issue #72](https://github.com/medialize/ally.js/issues/72)
-* changing [`ally.is.focusRelevant`][ally/is/focus-relevant] to properly handle `<object type="application/x-shockwave-flash">` in IE9 - [issue #71](https://github.com/medialize/ally.js/issues/71)
+* changing [`ally.is.focusRelevant`][ally/is/focus-relevant] to properly handle `<object type="application/x-shockwave-flash">` in IE9 - [Issue #71](https://github.com/medialize/ally.js/issues/71)
 * fixing [`ally.query.tabsequence`][ally/query/tabsequence] to return `<area>` elements at the correct position - [issue #5](https://github.com/medialize/ally.js/issues/5)
 * fixing [`ally.query.tabsequence`][ally/query/tabsequence] to properly sort within Shadow DOM - [issue #6](https://github.com/medialize/ally.js/issues/6)
 * refactoring [`ally.query.tabsequence`][ally/query/tabsequence] to extract `util/merge-dom-order` and `util/sort-dom-order`
+
+#### Keyboard support
+
+* changing [`ally.when.key`][ally/when/key] to handle modifier keys - [issue #59](https://github.com/medialize/ally.js/issues/59)
 
 #### Internals
 

--- a/build/metalsmith/assets/website.css
+++ b/build/metalsmith/assets/website.css
@@ -341,6 +341,7 @@ main table {
   border: 1px solid #E5E5E5;
   border-collapse: collapse;
   width: 100%;
+  word-break: normal;
 }
 main th,
 main td {

--- a/build/metalsmith/assets/website.css
+++ b/build/metalsmith/assets/website.css
@@ -340,6 +340,7 @@ main .example h1 {
 main table {
   border: 1px solid #E5E5E5;
   border-collapse: collapse;
+  width: 100%;
 }
 main th,
 main td {

--- a/docs/api/map/keycode.md
+++ b/docs/api/map/keycode.md
@@ -5,7 +5,7 @@ tags: data
 
 # ally.map.keycode
 
-Map of control [`event.keyCode`](https://developer.mozilla.org/en-US/docs/Web/API/event.keyCode)s.
+Map human readable names for [`event.keyCode`](https://developer.mozilla.org/en-US/docs/Web/API/event.keyCode)s.
 
 
 ## Description
@@ -26,18 +26,61 @@ var map = {
   enter: 13,
   escape: 27,
   space: 32,
+
+  // Function keys
+  f1: 112,
+  // ...
+
+  // Numeric keys
+  0: 48,
+  1: 49,
+  // ...
+  "num-0": 96,
+  "num-1": 97,
+  // ...
+
+  // Latin characters
+  a: 65,
+  // ...
+  z: 90,
 }
 ```
+
+The map knows the following keys:
+
+* `a` - `z`
+* `0` - `9`
+* `num-0` - `num-9` (number block)
+* `f1` - `f25` (function keys)
+* `down`, `left`, `right`, `up` (arrow keys)
+* `end`, `home`, `pageDown`, `page-down`, `pageUp`, `page-up`
+* `enter`, `escape`, `space`, `tab`
+* `alt`, `capsLock`, `caps-lock`, `ctrl`, `meta`, `shift`
+* `pause`, `insert`, `delete`, `backspace`
 
 
 ## Usage
 
 ```js
-console.log(ally.map.keycode.enter);
+console.log("keycode of enter", ally.map.keycode.enter);
 ```
 
 
+## Changes
+
+* `v#master` replaced the key `command` by `meta`.
+* `v#master` added `a` - `z`, `0` - `9`, `num-0` - `num-9`, `f13` - `f25`, `page-down`, `page-up`, `caps-lock`.
+* `v#master` added `_alias` to resolve multiple keyCodes for the same logical key.
+
+
+## Notes
+
+* **NOTE:** The key `meta` is known by different keyCodes: `91`, `92`, `93`, `224` - which `ally.map.keycodes.alias.91` helps to resolve. The same is true for numeric keys (0-9) and their counterparts on the numblock.
+
+
 ## Related resources
+
+* [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) may help deal with this mess in the future.
 
 
 ## Contributing

--- a/docs/api/when/key.md
+++ b/docs/api/when/key.md
@@ -12,6 +12,10 @@ Executes a callback when a given key has been pressed.
 
 This is a convenience API to avoid adding and removing keyboard event handlers and having to filter for specific keys in application code. Callbacks are executed synchronously while handling [`keydown`](https://developer.mozilla.org/en-US/docs/Web/Events/keydown) events to maintain the ability to [`event.preventDefault()`](https://developer.mozilla.org/en/docs/Web/API/Event/preventDefault).
 
+Keyboard events are dispatched to the currently focused element (`document.activeElement`). This allows us to handle keyboard events only when the user is engaged in a particular widget.
+
+### Key binding syntax
+
 In order to easily register keyboard events including modifier keys, `ally.when.key` understands the following `<key-binding>` syntax:
 
 | `<key-binding>` | primary key | keyCode | alt | ctrl | meta | shift |
@@ -22,26 +26,10 @@ In order to easily register keyboard events including modifier keys, `ally.when.
 | `shift+*+enter` | <kbd>Enter</kbd> | 13 | ? | ? | ? | yes |
 | `!shift+*+enter` | <kbd>Enter</kbd> | 13 | ? | ? | ? | no |
 | `?shift+ctrl+enter` | <kbd>Enter</kbd> | 13 | no | yes | no | ? |
+| `enter shift+8` | <kbd>Enter</kbd> | 13 | no | no | no | no |
+| *(continued)* | <kbd>Backspace</kbd> | 8 | no | no | no | yes |
 
 Legend: `no` means the modifier key is not pressed, `yes` means the modifier key is pressed, `?` means the state of the modifier key is ignored.
-
-* **NOTE:** The callback for the `<key-binding>` `space` only executes if *no* modifier key was pressed. In order to make the callback execute regardless of modifier keys, use the `<key-binding>` `*+space`.
-
-### Modifier keys
-
-The modifier keys may have different names/symbols depending on operating system and physical keyboard:
-
-| modifier key name | physical key on keyboard |
-|-------------------|--------------------------|
-| alt | <kbd>Alt</kbd>, <kbd>Option</kbd> or<kbd> ⌥</kbd> on Mac) |
-| ctrl | <kbd>Ctrl</kbd>, <kbd>⌃</kbd> on Mac |
-| meta | <kbd>Meta</kbd>, <kbd> ⌘</kbd> or <kbd></kbd> or <kbd>Command</kbd> on Mac, <kbd>⊞</kbd> or <kbd>Windows</kbd> on Windows |
-| shift | <kbd>Shift</kbd>, <kbd>⇧</kbd> on Mac |
-
-* **NOTE:** The modifiers `alt`, `ctrl`, `meta` usually engage system-level or browser-level functionality. Do not use these modifiers lightly. For example `alt+a` prints the letter `å` on a Mac with German keyboard layout, `meta+q` exits the application and `meta+space` engages Spotlight.
-
-
-### `<key-binding>` syntax
 
 The `<key-binding>` syntax is defined by the following [EBNF](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_Form) grammar, with `property of map/keycode` referring to the property names of [`ally.map.keycode`](../map/keycode.md):
 
@@ -54,6 +42,17 @@ keycode       = ? /[0-9]+/ ? ;
 modifier      = ( [ "!" | "?" ], modifier-name ) | "*" ;
 modifier-name = "alt" | "ctrl" | "meta" | "shift" ;
 ```
+
+### Modifier keys
+
+The modifier keys may have different names/symbols depending on operating system and physical keyboard:
+
+| modifier key name | physical key on keyboard |
+|-------------------|--------------------------|
+| alt | <kbd>Alt</kbd>, <kbd>Option</kbd> or<kbd> ⌥</kbd> on Mac) |
+| ctrl | <kbd>Ctrl</kbd>, <kbd>⌃</kbd> on Mac |
+| meta | <kbd>Meta</kbd>, <kbd> ⌘</kbd> or <kbd></kbd> or <kbd>Command</kbd> on Mac, <kbd>⊞</kbd> or <kbd>Windows</kbd> on Windows |
+| shift | <kbd>Shift</kbd>, <kbd>⇧</kbd> on Mac |
 
 
 ## Usage
@@ -76,9 +75,11 @@ handle.disengage();
 
 ### Arguments
 
-The method accepts an object of `<key-binding>: <callback>` mappings. See [Callback Signature](#Callback-Signature) for details
-
-`<key-binding>`s can be specified as a numeric code ([`keyCode`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode)) e.g. `13` for the <kbd>Enter</kbd> key, or as the string name `enter` which is resolved to the numeric code internally using [`ally.map.keycode`](../map/keycode.md). Multiple `<key-binding>: <callback>` combinations can be passed.
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| context | [`<selector>`](../concepts.md#Selector) | [`documentElement`](https://developer.mozilla.org/en-US/docs/Web/API/Document/documentElement) | The scope of the DOM in which keyboard events will be processed. The first element of a collection is used. |
+| filter | [`<selector>`](../concepts.md#Selector) | `null` | The elements and descendants to exclude when processing keyboard events. |
+| [`<key-binding>`](#Key-binding-syntax) | function | *required* | Mapping of `<key-binding>` to callback function. See [Callback Signature](#Callback-Signature) for details. This argument is expected one or more times. |
 
 ### Returns
 
@@ -86,10 +87,11 @@ A [`<service>`](../concepts.md#Service) interface, providing the `handle.disenga
 
 ### Throws
 
-* [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) if `<key-binding>` does not contain a key component, or is neither numeric nor found in [`ally.map.keycode`](../map/keycode.md).
-* [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) if `<callback>` is not a `function`.
-* [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) if `<key-binding>` contains illegal modifier names.
 * [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) if no `<key-binding>: <callback>` combinations were passed.
+* [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) if `<key-binding>` does not resolve to a keyCode.
+* [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) if `<key-binding>` contains illegal modifier names.
+* [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) if `<callback>` is not a `function`.
+
 
 ## Callback signature
 
@@ -98,7 +100,7 @@ A [`<service>`](../concepts.md#Service) interface, providing the `handle.disenga
 | event | [`KeyboardEvent`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent) | *required* | The original `keydown` event. |
 | disengage | function | *required* | The service's `handle.disengage()` method. |
 
-The callback is executed in the context of `document.documentElement` (that's where `this` inside the callback points to). The callback is passed the `handle.disengage()` method to allow simplified "execute once" behaviors. The callback's return value is ignored.
+The callback is executed in the context of `context` (that's where `this` inside the callback points to). The callback is passed the `handle.disengage()` method to allow simplified "execute once" behaviors. The callback's return value is ignored.
 
 
 ## Examples
@@ -109,17 +111,20 @@ The callback is executed in the context of `document.documentElement` (that's wh
 ## Changes
 
 * `v#master` introduced the extended `<key-binding>` syntax (thereby changing the default modifier key behavior).
+* `v#master` introduced the options `context` and `filter`.
 
 
 ## Notes
 
 * **NOTE:** Firefox has a long standing issue with keyboard events propagating to the document while browser UI like autocomplete is being interacted with [Gecko 286933](https://bugzilla.mozilla.org/show_bug.cgi?id=286933).
+* **WARNING:** The callback for the `<key-binding>` `space` only executes if *no* modifier key was pressed. In order to make the callback execute regardless of modifier keys, use the `<key-binding>` `*+space`.
+* **NOTE:** The modifiers `alt`, `ctrl`, `meta` usually engage system-level or browser-level functionality. Do not use these modifiers lightly. For example `alt+a` prints the letter `å` on a Mac with German keyboard layout, `meta+q` exits the application and `meta+space` engages Spotlight.
 
 
 ## Related resources
 
 * [`ally.map.keycode`](../map/keycode.md) used for resolving named keys
-* `<key-binding>` syntax inspired by [PolymerElements/iron-a11y-keys](https://github.com/PolymerElements/iron-a11y-keys#grammar)
+* The `<key-binding>` syntax is inspired by [PolymerElements/iron-a11y-keys](https://github.com/PolymerElements/iron-a11y-keys#grammar)
 
 
 ## Contributing

--- a/docs/api/when/key.md
+++ b/docs/api/when/key.md
@@ -10,7 +10,50 @@ Executes a callback when a given key has been pressed.
 
 ## Description
 
-This is a convenience API to avoid adding and removing keyboard event handlers and having to filter for specific keys in application code. Callbacks are executed on `keydown`.
+This is a convenience API to avoid adding and removing keyboard event handlers and having to filter for specific keys in application code. Callbacks are executed synchronously while handling [`keydown`](https://developer.mozilla.org/en-US/docs/Web/Events/keydown) events to maintain the ability to [`event.preventDefault()`](https://developer.mozilla.org/en/docs/Web/API/Event/preventDefault).
+
+In order to easily register keyboard events including modifier keys, `ally.when.key` understands the following `<key-binding>` syntax:
+
+| `<key-binding>` | primary key | keyCode | alt | ctrl | meta | shift |
+|-----------------|-------------|---------|-----|------|-------|------|
+| `space` | <kbd>Space</kbd> | 32 | no | no | no | no |
+| `*+space` | <kbd>Space</kbd> | 32 | ? | ? | ? | ? |
+| `shift+space` | <kbd>Space</kbd> | 32 | no | no | no | yes |
+| `shift+*+enter` | <kbd>Enter</kbd> | 13 | ? | ? | ? | yes |
+| `!shift+*+enter` | <kbd>Enter</kbd> | 13 | ? | ? | ? | no |
+| `?shift+ctrl+enter` | <kbd>Enter</kbd> | 13 | no | yes | no | ? |
+
+Legend: `no` means the modifier key is not pressed, `yes` means the modifier key is pressed, `?` means the state of the modifier key is ignored.
+
+* **NOTE:** The callback for the `<key-binding>` `space` only executes if *no* modifier key was pressed. In order to make the callback execute regardless of modifier keys, use the `<key-binding>` `*+space`.
+
+### Modifier keys
+
+The modifier keys may have different names/symbols depending on operating system and physical keyboard:
+
+| modifier key name | physical key on keyboard |
+|-------------------|--------------------------|
+| alt | <kbd>Alt</kbd>, <kbd>Option</kbd> or<kbd> ⌥</kbd> on Mac) |
+| ctrl | <kbd>Ctrl</kbd>, <kbd>⌃</kbd> on Mac |
+| meta | <kbd>Meta</kbd>, <kbd> ⌘</kbd> or <kbd></kbd> or <kbd>Command</kbd> on Mac, <kbd>⊞</kbd> or <kbd>Windows</kbd> on Windows |
+| shift | <kbd>Shift</kbd>, <kbd>⇧</kbd> on Mac |
+
+* **NOTE:** The modifiers `alt`, `ctrl`, `meta` usually engage system-level or browser-level functionality. Do not use these modifiers lightly. For example `alt+a` prints the letter `å` on a Mac with German keyboard layout, `meta+q` exits the application and `meta+space` engages Spotlight.
+
+
+### `<key-binding>` syntax
+
+The `<key-binding>` syntax is defined by the following [EBNF](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_Form) grammar, with `property of map/keycode` referring to the property names of [`ally.map.keycode`](../map/keycode.md):
+
+```ebnf
+token-list    = token, { " ", token } ;
+token         = { modifier, "+" }, key ;
+key           = named-key | keycode ;
+named-key     = ? property of ally.map.keycode ? ;
+keycode       = ? /[0-9]+/ ? ;
+modifier      = ( [ "!" | "?" ], modifier-name ) | "*" ;
+modifier-name = "alt" | "ctrl" | "meta" | "shift" ;
+```
 
 
 ## Usage
@@ -33,9 +76,9 @@ handle.disengage();
 
 ### Arguments
 
-The method accepts an object of `<key>: <callback>` mappings. See [Callback Signature](#Callback-Signature) for details
+The method accepts an object of `<key-binding>: <callback>` mappings. See [Callback Signature](#Callback-Signature) for details
 
-`<key>`s can be specified as a numeric code ([`keyCode`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode)) e.g. `13` for the <kbd>Enter</kbd> key, or as the string name `enter` which is resolved to the numeric code internally using [`ally.map.keycode`](../map/keycode.md). Multiple `<key>: <callback>` combinations can be passed.
+`<key-binding>`s can be specified as a numeric code ([`keyCode`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode)) e.g. `13` for the <kbd>Enter</kbd> key, or as the string name `enter` which is resolved to the numeric code internally using [`ally.map.keycode`](../map/keycode.md). Multiple `<key-binding>: <callback>` combinations can be passed.
 
 ### Returns
 
@@ -43,9 +86,10 @@ A [`<service>`](../concepts.md#Service) interface, providing the `handle.disenga
 
 ### Throws
 
-* [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) if `<ke>` is neither numeric, nor found in [`ally.map.keycode`](../map/keycode.md).
+* [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) if `<key-binding>` does not contain a key component, or is neither numeric nor found in [`ally.map.keycode`](../map/keycode.md).
 * [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) if `<callback>` is not a `function`.
-* [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) when no `<key>: <callback>` combinations were passed.
+* [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) if `<key-binding>` contains illegal modifier names.
+* [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) if no `<key-binding>: <callback>` combinations were passed.
 
 ## Callback signature
 
@@ -62,6 +106,11 @@ The callback is executed in the context of `document.documentElement` (that's wh
 * **EXAMPLE:** [`ally.when.key` Example](./key.example.html)
 
 
+## Changes
+
+* `v#master` introduced the extended `<key-binding>` syntax (thereby changing the default modifier key behavior).
+
+
 ## Notes
 
 * **NOTE:** Firefox has a long standing issue with keyboard events propagating to the document while browser UI like autocomplete is being interacted with [Gecko 286933](https://bugzilla.mozilla.org/show_bug.cgi?id=286933).
@@ -70,6 +119,7 @@ The callback is executed in the context of `document.documentElement` (that's wh
 ## Related resources
 
 * [`ally.map.keycode`](../map/keycode.md) used for resolving named keys
+* `<key-binding>` syntax inspired by [PolymerElements/iron-a11y-keys](https://github.com/PolymerElements/iron-a11y-keys#grammar)
 
 
 ## Contributing
@@ -77,4 +127,4 @@ The callback is executed in the context of `document.documentElement` (that's wh
 * [module source](https://github.com/medialize/ally.js/blob/master/src/when/key.js)
 * [document source](https://github.com/medialize/ally.js/blob/master/docs/api/when/key.md)
 * [unit test](https://github.com/medialize/ally.js/blob/master/test/unit/when.key.test.js)
-
+* uses [when/key.binding](https://github.com/medialize/ally.js/blob/master/src/when/key.binding.js) to parse `<key-binding>`

--- a/src/map/keycode.js
+++ b/src/map/keycode.js
@@ -1,7 +1,11 @@
 
-// https://github.com/keithamus/jwerty/blob/master/jwerty.js
+// codes mostly cloned from https://github.com/keithamus/jwerty/blob/master/jwerty.js
+// deliberately not exposing characters like <,.-#* because they vary *wildly*
+// across keyboard layouts and may cause various problems
+// (e.g. "*" is "Shift +" on a German Mac keyboard)
+// (e.g. "@" is "Alt L" on a German Mac keyboard)
 
-export default {
+const keycode = {
   // Element Focus
   tab: 9,
 
@@ -11,7 +15,9 @@ export default {
   right: 39,
   down: 40,
   pageUp: 33,
+  'page-up': 33,
   pageDown: 34,
+  'page-down': 34,
   end: 35,
   home: 36,
 
@@ -23,9 +29,13 @@ export default {
   // Modifier
   shift: 16,
   capsLock: 20,
+  'caps-lock': 20,
   ctrl: 17,
   alt: 18,
-  command: 224,
+  meta: 91,
+  // in firefox: 224
+  // on mac (chrome): meta-left=91, meta-right=93
+  // on win (IE11): meta-left=91, meta-right=92
   pause: 19,
 
   // Content Manipulation
@@ -33,17 +43,33 @@ export default {
   'delete': 46,
   backspace: 8,
 
-  // Special Function
-  f1: 112,
-  f2: 113,
-  f3: 114,
-  f4: 115,
-  f5: 116,
-  f6: 117,
-  f7: 118,
-  f8: 119,
-  f9: 120,
-  f10: 121,
-  f11: 122,
-  f12: 123,
+  // the same logical key may be identified through different keyCodes
+  _alias: {
+    91: [92, 93, 224],
+  },
 };
+
+// Function keys (112 - 137)
+// NOTE: not every keyboard knows F13+
+for (let n = 1; n < 26; n++) {
+  keycode['f' + n] = n + 111;
+}
+
+// Number keys (48-57, numpad 96-105)
+// NOTE: not every keyboard knows num-0+
+for (let n = 0; n < 10; n++) {
+  const code = n + 48;
+  const numCode = n + 96;
+  keycode[n] = code;
+  keycode['num-' + n] = numCode;
+  keycode._alias[code] = [numCode];
+}
+
+// Latin characters (65 - 90)
+for (let n = 0; n < 26; n++) {
+  const code = n + 65;
+  const name = String.fromCharCode(code).toLowerCase();
+  keycode[name] = code;
+}
+
+export default keycode;

--- a/src/when/key.binding.js
+++ b/src/when/key.binding.js
@@ -4,8 +4,8 @@
 
   returns an array of objects:
     {
-      // translated key name
-      keyCode: <number>,
+      // key name translated to keyCode (possibly more than one)
+      keyCodes: [<number>],
       // translated modifiers
       modifiers: {
         altKey: null,   // ignore
@@ -83,7 +83,7 @@ function resolveKey(key) {
     throw new TypeError('Unknown key "' + key + '"');
   }
 
-  return code;
+  return [code].concat(keycode._alias[code] || []);
 }
 
 function matchModifiers(expected, event) {
@@ -98,9 +98,9 @@ export default function(text) {
   return text.split(/\s+/).map(function(_text) {
     const tokens = _text.split('+');
     const _modifiers = resolveModifiers(tokens.slice(0, -1));
-    const _key = resolveKey(tokens.slice(-1));
+    const _keyCodes = resolveKey(tokens.slice(-1));
     return {
-      keyCode: _key,
+      keyCodes: _keyCodes,
       modifiers: _modifiers,
       matchModifiers: matchModifiers.bind(null, _modifiers),
     };

--- a/src/when/key.binding.js
+++ b/src/when/key.binding.js
@@ -1,0 +1,108 @@
+
+/*
+  decodes a key binding token to a JavaScript structure
+
+  returns an array of objects:
+    {
+      // translated key name
+      keyCode: <number>,
+      // translated modifiers
+      modifiers: {
+        altKey: null,   // ignore
+        ctrKey: false,  // expect not pressed
+        metaKey: true,  // expect pressed
+        shiftKey: true, // expect pressed
+      },
+      // callback that returns true if event's
+      // modifier keys match the expected state
+      matchModifiers: function(event){},
+    }
+*/
+
+import keycode from '../map/keycode';
+
+const modifier = {
+  alt: 'altKey',
+  ctrl: 'ctrlKey',
+  meta: 'metaKey',
+  shift: 'shiftKey',
+};
+
+const modifierSequence = Object.keys(modifier).map(name => modifier[name]);
+
+function createExpectedModifiers(ignoreModifiers) {
+  const value = ignoreModifiers ? null : false;
+  return {
+    altKey: value,
+    ctrlKey: value,
+    metaKey: value,
+    shiftKey: value,
+  };
+}
+
+function resolveModifiers(modifiers) {
+  const ignoreModifiers = modifiers.indexOf('*') !== -1;
+  const expected = createExpectedModifiers(ignoreModifiers);
+
+  modifiers.forEach(function(token) {
+    if (token === '*') {
+      // we've already covered the all-in operator
+      return;
+    }
+
+    // we want the modifier pressed
+    let value = true;
+    const operator = token.slice(0, 1);
+    if (operator === '?') {
+      // we don't care if the modifier is pressed
+      value = null;
+    } else if (operator === '!') {
+      // we do not want the modifier pressed
+      value = false;
+    }
+
+    if (value !== true) {
+      // compensate for the modifier's operator
+      token = token.slice(1);
+    }
+
+    const propertyName = modifier[token];
+    if (!propertyName) {
+      throw new TypeError('Unknown modifier "' + token + '"');
+    }
+
+    expected[propertyName] = value;
+  });
+
+  return expected;
+}
+
+function resolveKey(key) {
+  const code = keycode[key] || parseInt(key, 10);
+  if (!code || typeof code !== 'number' || isNaN(code)) {
+    throw new TypeError('Unknown key "' + key + '"');
+  }
+
+  return code;
+}
+
+function matchModifiers(expected, event) {
+  // returns true on match
+  return !modifierSequence.some(function(prop) {
+    // returns true on mismatch
+    return typeof expected[prop] === 'boolean' && Boolean(event[prop]) !== expected[prop];
+  });
+}
+
+export default function(text) {
+  return text.split(/\s+/).map(function(_text) {
+    const tokens = _text.split('+');
+    const _modifiers = resolveModifiers(tokens.slice(0, -1));
+    const _key = resolveKey(tokens.slice(-1));
+    return {
+      keyCode: _key,
+      modifiers: _modifiers,
+      matchModifiers: matchModifiers.bind(null, _modifiers),
+    };
+  });
+}

--- a/src/when/key.js
+++ b/src/when/key.js
@@ -14,11 +14,13 @@ export default function(map = {}) {
   }
 
   const registerBinding = function(event) {
-    if (!bindings[event.keyCode]) {
-      bindings[event.keyCode] = [];
-    }
+    event.keyCodes.forEach(function(code) {
+      if (!bindings[code]) {
+        bindings[code] = [];
+      }
 
-    bindings[event.keyCode].push(event);
+      bindings[code].push(event);
+    });
   };
 
   mapKeys.forEach(function(text) {

--- a/test/helper/dispatch-event.js
+++ b/test/helper/dispatch-event.js
@@ -11,10 +11,15 @@ define([], function() {
     var event = document.createEvent('KeyboardEvent');
     if (event.initKeyEvent) {
       // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/initKeyEvent
-      event.initKeyEvent(type, true, false, null, false, false, false, false, options.keyCode, 0);
+      event.initKeyEvent(type, true, false, null, !!options.ctrlKey, !!options.altKey, !!options.shiftKey, !!options.metaKey, options.keyCode, 0);
     } else {
       // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/initKeyboardEvent
-      event.initKeyboardEvent(type, true, false, null, '', options.keyCode, null, '', false);
+      var modifiers = [];
+      options.altKey && modifiers.push('Alt');
+      options.ctrlKey && modifiers.push('Ctrl');
+      options.metaKey && modifiers.push('Meta');
+      options.shiftKey && modifiers.push('Shift');
+      event.initKeyboardEvent(type, true, false, null, '', options.keyCode, null, modifiers.join(' '), false);
     }
 
     try {
@@ -22,6 +27,10 @@ define([], function() {
       // http://stackoverflow.com/questions/1897333/firing-a-keyboard-event-on-chrome
       Object.defineProperty(event, 'keyCode', {value: options.keyCode});
       Object.defineProperty(event, 'which', {value: options.keyCode});
+      Object.defineProperty(event, 'altKey', {value: !!options.altKey});
+      Object.defineProperty(event, 'ctrlKey', {value: !!options.ctrlKey});
+      Object.defineProperty(event, 'metaKey', {value: !!options.metaKey});
+      Object.defineProperty(event, 'shiftKey', {value: !!options.shiftKey});
       // Internet Explorer does not like this
       event.keyCode = options.keyCode;
     } catch(e) {
@@ -84,6 +93,23 @@ define([], function() {
       }
 
       return event;
+    },
+    preventDefault: function(event) {
+      event.preventDefault();
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      try {
+        // Safari 7 does not like this: ATTEMPTING TO CHANGE VALUE OF A READONLY PROPERTY
+        // http://stackoverflow.com/questions/1897333/firing-a-keyboard-event-on-chrome
+        Object.defineProperty(event, 'defaultPrevented', {value: true});
+        // Internet Explorer does not like this
+        event.defaultPrevented = true;
+      } catch(e) {
+        // IGNORE
+        return;
+      }
     },
   };
 

--- a/test/unit/when.key.test.js
+++ b/test/unit/when.key.test.js
@@ -239,7 +239,7 @@ define([
         expect(events).to.be.a('array');
         expect(events.length).to.equal(1);
 
-        expect(events[0].keyCode).to.equal(13, 'keyCode');
+        expect(events[0].keyCodes.join(',')).to.equal('13', 'keyCode');
         expect(events[0].modifiers.altKey).to.equal(false, 'alt modifier');
         expect(events[0].modifiers.ctrlKey).to.equal(false, 'ctrl modifier');
         expect(events[0].modifiers.metaKey).to.equal(false, 'meta modifier');
@@ -250,7 +250,7 @@ define([
         expect(events).to.be.a('array');
         expect(events.length).to.equal(1);
 
-        expect(events[0].keyCode).to.equal(13);
+        expect(events[0].keyCodes.join(',')).to.equal('13', 'keyCode');
         expect(events[0].modifiers.altKey).to.equal(false, 'alt modifier');
         expect(events[0].modifiers.ctrlKey).to.equal(false, 'ctrl modifier');
         expect(events[0].modifiers.metaKey).to.equal(false, 'meta modifier');
@@ -261,7 +261,7 @@ define([
         expect(events).to.be.a('array');
         expect(events.length).to.equal(1);
 
-        expect(events[0].keyCode).to.equal(13);
+        expect(events[0].keyCodes.join(',')).to.equal('13', 'keyCode');
         expect(events[0].modifiers.altKey).to.equal(null, 'alt modifier');
         expect(events[0].modifiers.ctrlKey).to.equal(null, 'ctrl modifier');
         expect(events[0].modifiers.metaKey).to.equal(null, 'meta modifier');
@@ -272,7 +272,7 @@ define([
         expect(events).to.be.a('array');
         expect(events.length).to.equal(1);
 
-        expect(events[0].keyCode).to.equal(13);
+        expect(events[0].keyCodes.join(',')).to.equal('13', 'keyCode');
         expect(events[0].modifiers.altKey).to.equal(null, 'alt modifier');
         expect(events[0].modifiers.ctrlKey).to.equal(null, 'ctrl modifier');
         expect(events[0].modifiers.metaKey).to.equal(null, 'meta modifier');
@@ -283,7 +283,7 @@ define([
         expect(events).to.be.a('array');
         expect(events.length).to.equal(1);
 
-        expect(events[0].keyCode).to.equal(13);
+        expect(events[0].keyCodes.join(',')).to.equal('13', 'keyCode');
         expect(events[0].modifiers.altKey).to.equal(null, 'alt modifier');
         expect(events[0].modifiers.ctrlKey).to.equal(false, 'ctrl modifier');
         expect(events[0].modifiers.metaKey).to.equal(null, 'meta modifier');
@@ -294,7 +294,7 @@ define([
         expect(events).to.be.a('array');
         expect(events.length).to.equal(1);
 
-        expect(events[0].keyCode).to.equal(13);
+        expect(events[0].keyCodes.join(',')).to.equal('13', 'keyCode');
         expect(events[0].modifiers.altKey).to.equal(false, 'alt modifier');
         expect(events[0].modifiers.ctrlKey).to.equal(false, 'ctrl modifier');
         expect(events[0].modifiers.metaKey).to.equal(null, 'meta modifier');
@@ -305,17 +305,25 @@ define([
         expect(events).to.be.a('array');
         expect(events.length).to.equal(2);
 
-        expect(events[0].keyCode).to.equal(13);
+        expect(events[0].keyCodes.join(',')).to.equal('13', 'keyCode');
         expect(events[0].modifiers.altKey).to.equal(false, 'alt modifier for enter');
         expect(events[0].modifiers.ctrlKey).to.equal(false, 'ctrl modifier for enter');
         expect(events[0].modifiers.metaKey).to.equal(null, 'meta modifier for enter');
         expect(events[0].modifiers.shiftKey).to.equal(false, 'shift modifier for enter');
 
-        expect(events[1].keyCode).to.equal(32);
+        expect(events[1].keyCodes.join(',')).to.equal('32', 'keyCode');
         expect(events[1].modifiers.altKey).to.equal(false, 'alt modifier for space');
         expect(events[1].modifiers.ctrlKey).to.equal(false, 'ctrl modifier for space');
         expect(events[1].modifiers.metaKey).to.equal(false, 'meta modifier for space');
         expect(events[1].modifiers.shiftKey).to.equal(true, 'shift modifier for space');
+      },
+      'parse token with aliased codes': function() {
+        var events = keyBinding('0 meta');
+        expect(events).to.be.a('array');
+        expect(events.length).to.equal(2);
+
+        expect(events[0].keyCodes.join(',')).to.equal('48,96', 'keyCode');
+        expect(events[1].keyCodes.join(',')).to.equal('91,92,93,224', 'keyCode');
       },
     };
   });

--- a/test/unit/when.key.test.js
+++ b/test/unit/when.key.test.js
@@ -3,10 +3,15 @@ define([
   'intern/chai!expect',
   '../helper/dispatch-event',
   'ally/when/key',
-], function(registerSuite, expect, dispatchEvent, whenKey) {
+  'ally/when/key.binding',
+], function(registerSuite, expect, dispatchEvent, whenKey, keyBinding) {
 
   registerSuite(function() {
     var handle;
+
+    var preventDefaultKeydown = function(event) {
+      dispatchEvent.preventDefault(event);
+    };
 
     return {
       name: 'when/key',
@@ -17,6 +22,7 @@ define([
       afterEach: function() {
         // make sure a failed test cannot leave listeners behind
         handle && handle.disengage({ force: true });
+        document.documentElement.removeEventListener('keydown', preventDefaultKeydown, true);
       },
 
       'invalid invocation': function() {
@@ -28,13 +34,25 @@ define([
           handle = whenKey({
             world: function() {},
           });
-        }).to.throw(TypeError, 'when/key requires option keys to be numeric or references to map/keycode, but "world" is neither');
+        }).to.throw(TypeError, 'Unknown key "world"');
 
         expect(function() {
           handle = whenKey({
             enter: true,
           });
-        }).to.throw(TypeError, 'when/key requires option.enter to be a function');
+        }).to.throw(TypeError, 'when/key requires option["enter"] to be a function');
+
+        expect(function() {
+          handle = whenKey({
+            'enter+shift': function() {},
+          });
+        }).to.throw(TypeError, 'Unknown modifier "enter"');
+
+        expect(function() {
+          handle = whenKey({
+            'shaft+enter': function() {},
+          });
+        }).to.throw(TypeError, 'Unknown modifier "shaft"');
       },
 
       lifecycle: function() {
@@ -121,6 +139,184 @@ define([
         expect(events.join(', ')).to.equal('enter', 'after escape event');
       },
 
+      defaultPrevented: function() {
+        var supportsSynthEvent = dispatchEvent.createKey('keydown', {
+          key: 'Enter',
+          keyCode: 13,
+        });
+
+        if (supportsSynthEvent.keyCode !== 13) {
+          this.skip('Synthetic enter events not supported');
+        }
+
+        document.documentElement.addEventListener('keydown', preventDefaultKeydown, true);
+
+        var events = [];
+        handle = whenKey({
+          enter: function() {
+            events.push('enter');
+          },
+        });
+
+        expect(events.join(', ')).to.equal('', 'before events');
+
+        dispatchEvent.key(document.documentElement, 'keydown', {
+          key: 'Enter',
+          keyCode: 13,
+        });
+
+        expect(events.join(', ')).to.equal('', 'after prevented enter event');
+
+        document.documentElement.removeEventListener('keydown', preventDefaultKeydown, true);
+
+        dispatchEvent.key(document.documentElement, 'keydown', {
+          key: 'Enter',
+          keyCode: 13,
+        });
+
+        expect(events.join(', ')).to.equal('enter', 'after unprevented enter event');
+      },
+
+      modifiers: function() {
+        var supportsSynthEvent = dispatchEvent.createKey('keydown', {
+          key: 'Enter',
+          keyCode: 13,
+          shiftKey: true,
+        });
+
+        if (supportsSynthEvent.keyCode !== 13) {
+          this.skip('Synthetic enter events not supported');
+        }
+
+        var events = [];
+        handle = whenKey({
+          enter: function() {
+            events.push('enter');
+          },
+          'shift+enter': function() {
+            events.push('shift enter');
+          },
+          'shift+ctrl+enter': function() {
+            events.push('shift ctrl enter');
+          },
+        });
+
+        expect(events.join(', ')).to.equal('', 'before events');
+
+        dispatchEvent.key(document.documentElement, 'keydown', {
+          key: 'Space',
+          keyCode: 32,
+        });
+
+        expect(events.join(', ')).to.equal('', 'after space event');
+
+        dispatchEvent.key(document.documentElement, 'keydown', {
+          key: 'Enter',
+          keyCode: 13,
+        });
+
+        expect(events.join(', ')).to.equal('enter', 'after enter event');
+
+        dispatchEvent.key(document.documentElement, 'keydown', {
+          key: 'Enter',
+          keyCode: 13,
+          shiftKey: true,
+        });
+
+        expect(events.join(', ')).to.equal('enter, shift enter', 'after shift+enter event');
+
+        dispatchEvent.key(document.documentElement, 'keydown', {
+          key: 'Enter',
+          keyCode: 13,
+          ctrlKey: true,
+          shiftKey: true,
+        });
+
+        expect(events.join(', ')).to.equal('enter, shift enter, shift ctrl enter', 'after shift+ctrl+enter event');
+      },
+      'parse token "enter"': function() {
+        var events = keyBinding('enter');
+        expect(events).to.be.a('array');
+        expect(events.length).to.equal(1);
+
+        expect(events[0].keyCode).to.equal(13, 'keyCode');
+        expect(events[0].modifiers.altKey).to.equal(false, 'alt modifier');
+        expect(events[0].modifiers.ctrlKey).to.equal(false, 'ctrl modifier');
+        expect(events[0].modifiers.metaKey).to.equal(false, 'meta modifier');
+        expect(events[0].modifiers.shiftKey).to.equal(false, 'shift modifier');
+      },
+      'parse token "shift+enter"': function() {
+        var events = keyBinding('shift+enter');
+        expect(events).to.be.a('array');
+        expect(events.length).to.equal(1);
+
+        expect(events[0].keyCode).to.equal(13);
+        expect(events[0].modifiers.altKey).to.equal(false, 'alt modifier');
+        expect(events[0].modifiers.ctrlKey).to.equal(false, 'ctrl modifier');
+        expect(events[0].modifiers.metaKey).to.equal(false, 'meta modifier');
+        expect(events[0].modifiers.shiftKey).to.equal(true, 'shift modifier');
+      },
+      'parse token "*+enter"': function() {
+        var events = keyBinding('*+enter');
+        expect(events).to.be.a('array');
+        expect(events.length).to.equal(1);
+
+        expect(events[0].keyCode).to.equal(13);
+        expect(events[0].modifiers.altKey).to.equal(null, 'alt modifier');
+        expect(events[0].modifiers.ctrlKey).to.equal(null, 'ctrl modifier');
+        expect(events[0].modifiers.metaKey).to.equal(null, 'meta modifier');
+        expect(events[0].modifiers.shiftKey).to.equal(null, 'shift modifier');
+      },
+      'parse token "shift+*+enter"': function() {
+        var events = keyBinding('shift+*+enter');
+        expect(events).to.be.a('array');
+        expect(events.length).to.equal(1);
+
+        expect(events[0].keyCode).to.equal(13);
+        expect(events[0].modifiers.altKey).to.equal(null, 'alt modifier');
+        expect(events[0].modifiers.ctrlKey).to.equal(null, 'ctrl modifier');
+        expect(events[0].modifiers.metaKey).to.equal(null, 'meta modifier');
+        expect(events[0].modifiers.shiftKey).to.equal(true, 'shift modifier');
+      },
+      'parse token "!ctrl+shift+*+enter"': function() {
+        var events = keyBinding('!ctrl+shift+*+enter');
+        expect(events).to.be.a('array');
+        expect(events.length).to.equal(1);
+
+        expect(events[0].keyCode).to.equal(13);
+        expect(events[0].modifiers.altKey).to.equal(null, 'alt modifier');
+        expect(events[0].modifiers.ctrlKey).to.equal(false, 'ctrl modifier');
+        expect(events[0].modifiers.metaKey).to.equal(null, 'meta modifier');
+        expect(events[0].modifiers.shiftKey).to.equal(true, 'shift modifier');
+      },
+      'parse token "?meta+enter"': function() {
+        var events = keyBinding('?meta+enter');
+        expect(events).to.be.a('array');
+        expect(events.length).to.equal(1);
+
+        expect(events[0].keyCode).to.equal(13);
+        expect(events[0].modifiers.altKey).to.equal(false, 'alt modifier');
+        expect(events[0].modifiers.ctrlKey).to.equal(false, 'ctrl modifier');
+        expect(events[0].modifiers.metaKey).to.equal(null, 'meta modifier');
+        expect(events[0].modifiers.shiftKey).to.equal(false, 'shift modifier');
+      },
+      'parse token "?meta+enter shift+space"': function() {
+        var events = keyBinding('?meta+enter shift+space');
+        expect(events).to.be.a('array');
+        expect(events.length).to.equal(2);
+
+        expect(events[0].keyCode).to.equal(13);
+        expect(events[0].modifiers.altKey).to.equal(false, 'alt modifier for enter');
+        expect(events[0].modifiers.ctrlKey).to.equal(false, 'ctrl modifier for enter');
+        expect(events[0].modifiers.metaKey).to.equal(null, 'meta modifier for enter');
+        expect(events[0].modifiers.shiftKey).to.equal(false, 'shift modifier for enter');
+
+        expect(events[1].keyCode).to.equal(32);
+        expect(events[1].modifiers.altKey).to.equal(false, 'alt modifier for space');
+        expect(events[1].modifiers.ctrlKey).to.equal(false, 'ctrl modifier for space');
+        expect(events[1].modifiers.metaKey).to.equal(false, 'meta modifier for space');
+        expect(events[1].modifiers.shiftKey).to.equal(true, 'shift modifier for space');
+      },
     };
   });
 });


### PR DESCRIPTION
covers #59

* extends `map/keycode`
* adds options `context`, `filter`
* adds key binding syntax derived from iron-a11y-keys