### PR TITLE
Test/browserstack safari

### DIFF
--- a/src/query/tabsequence.sort-area.js
+++ b/src/query/tabsequence.sort-area.js
@@ -1,7 +1,7 @@
 
 // move <area> elements to the location of the <img> elements that reference them
 
-import 'css.escape';
+import cssEscape from 'css.escape';
 import 'array.prototype.findindex';
 import queryTabbable from './tabbable';
 import mergeInDomOrder from '../util/merge-dom-order';
@@ -26,7 +26,7 @@ class Maps {
   addMapByName(name) {
     // apparently getElementsByName() also considers id attribute in IE & opera
     // https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByName
-    const map = this._document.querySelector('map[name="' + CSS.escape(name) + '"]') || null;
+    const map = this._document.querySelector('map[name="' + cssEscape(name) + '"]') || null;
     if (!map) {
       // if there is no map, the img[usemap] wasn't doing anything anyway
       return;

--- a/test/browserstack.js
+++ b/test/browserstack.js
@@ -18,21 +18,22 @@ define([
   // see https://www.browserstack.com/automate/capabilities
   /*eslint-disable camelcase */
   config.environments = [
+    // disabled because of https://github.com/theintern/intern/issues/555
     // { browser: 'Edge', browser_version: '12.0', os: 'WINDOWS', os_version: '10', platform: 'WIN', browserName: 'Edge12' },
     { browser: 'IE', browser_version: '11', os: 'WINDOWS', os_version: '8.1', platform: 'WIN', browserName: 'IE11' },
     { browser: 'IE', browser_version: '10', os: 'WINDOWS', os_version: '8', platform: 'WIN', browserName: 'IE10' },
     { browser: 'IE', browser_version: '9', os: 'WINDOWS', os_version: '7', platform: 'WIN', browserName: 'IE9' },
 
-    { browser: 'Firefox', browser_version: '41', os: 'WINDOWS', os_version: '8.1', platform: 'WIN', browserName: 'Firefox 41' },
-    { browser: 'Chrome', browser_version: '46', os: 'WINDOWS', os_version: '8.1', platform: 'WIN', browserName: 'Chrome 46' },
+    { browser: 'Firefox', browser_version: '42', os: 'WINDOWS', os_version: '8.1', platform: 'WIN', browserName: 'Firefox 42' },
+    { browser: 'Chrome', browser_version: '47', os: 'WINDOWS', os_version: '8.1', platform: 'WIN', browserName: 'Chrome 47' },
 
-    { browser: 'Firefox', browser_version: '41', os: 'OS X', os_version: 'Yosemite', platform: 'MAC', browserName: 'Firefox 41' },
-    { browser: 'Chrome', browser_version: '46', os: 'OS X', os_version: 'Yosemite', platform: 'MAC', browserName: 'Chrome 46' },
+    { browser: 'Firefox', browser_version: '42', os: 'OS X', os_version: 'Yosemite', platform: 'MAC', browserName: 'Firefox 42' },
+    { browser: 'Chrome', browser_version: '47', os: 'OS X', os_version: 'Yosemite', platform: 'MAC', browserName: 'Chrome 47' },
 
-    // disabled because of https://github.com/theintern/intern/issues/481
-    // { browser: 'Safari', browser_version: '8', os: 'OS X', os_version: 'Yosemite', platform: 'MAC', browserName: 'Safari 8' },
-    // { browser: 'Safari', browser_version: '7.1', os: 'OS X', os_version: 'Mavericks', platform: 'MAC', browserName: 'Safari 7' },
-    // { browser: 'Safari', browser_version: '6.2', os: 'OS X', os_version: 'Mountain Lion', platform: 'MAC', browserName: 'Safari 6' },
+    { browser: 'Safari', browser_version: '9.0', os: 'OS X', os_version: 'El Capitan', platform: 'MAC', browserName: 'Safari 9' },
+    { browser: 'Safari', browser_version: '8', os: 'OS X', os_version: 'Yosemite', platform: 'MAC', browserName: 'Safari 8' },
+    { browser: 'Safari', browser_version: '7.1', os: 'OS X', os_version: 'Mavericks', platform: 'MAC', browserName: 'Safari 7' },
+    { browser: 'Safari', browser_version: '6.2', os: 'OS X', os_version: 'Mountain Lion', platform: 'MAC', browserName: 'Safari 6' },
   ];
   /*eslint-enable camelcase */
 

--- a/test/helper/fixtures/focusable.fixture.js
+++ b/test/helper/fixtures/focusable.fixture.js
@@ -1,11 +1,15 @@
 define([
   './custom.fixture',
+  'platform',
   'ally/supports/media/gif',
   'ally/supports/media/svg',
   'ally/supports/media/mp3',
   'ally/supports/media/mp4',
-], function(customFixture, gif, svg, mp3, mp4) {
+], function(customFixture, platform, gif, svg, mp3, mp4) {
   return function(context) {
+
+    var avoidQuicktime = platform.name === 'Safari';
+
     return customFixture([
       /*eslint-disable indent */
       // tabindex attribute
@@ -34,8 +38,8 @@ define([
           '<text x="10" y="20" id="svg-link-text">text</text>',
         '</a>',
       '</svg>',
-      '<embed id="embed" type="video/mp4" src="' + mp4 + '" width="640" height="480">',
-      '<embed id="embed-tabindex-0" type="video/mp4" src="' + mp4 + '" width="640" height="480" tabindex="0">',
+      (!avoidQuicktime && '<embed id="embed" type="video/mp4" src="' + mp4 + '" width="640" height="480">') || '',
+      (!avoidQuicktime && '<embed id="embed-tabindex-0" type="video/mp4" src="' + mp4 + '" width="640" height="480" tabindex="0">') || '',
       '<embed type="image/svg+xml" id="embed-svg" data="' + svg + '" width="200" height="50">',
       '<embed type="image/svg+xml" id="embed-tabindex-svg" tabindex="-1" data="' + svg + '" width="200" height="50">',
       // interactive content

--- a/test/unit/is.focus-relevant.test.js
+++ b/test/unit/is.focus-relevant.test.js
@@ -157,10 +157,18 @@ define([
       },
       'embed element': function() {
         var element = document.getElementById('embed');
+        if (!element) {
+          this.skip('skipping to avoid test colliding with QuickTime');
+        }
+
         expect(isFocusRelevant(element)).to.equal(true);
       },
       'embed element with tabindex="0"': function() {
         var element = document.getElementById('embed-tabindex-0');
+        if (!element) {
+          this.skip('skipping to avoid test colliding with QuickTime');
+        }
+
         expect(isFocusRelevant(element)).to.equal(true);
       },
       'extended: CSS user-modify': function() {

--- a/test/unit/query.focusable.all.test.js
+++ b/test/unit/query.focusable.all.test.js
@@ -37,6 +37,7 @@ define([
           strategy: 'all',
         });
 
+        var canTestVideoEmbed = Boolean(document.getElementById('embed'));
         var expected = '#tabindex--1, #tabindex-0, #tabindex-1'
           + (supports.canFocusInvalidTabindex ? ', #tabindex-bad' : '')
           + ', #link, #link-tabindex--1'
@@ -46,7 +47,7 @@ define([
           + (platform.name === 'IE' ? ', #svg' : '')
           + (supports.canFocusObjectSvg ? ', #object-tabindex-svg' : '')
           + ', #svg-link'
-          + ', #embed, #embed-tabindex-0, #embed-svg, #embed-tabindex-svg'
+          + (canTestVideoEmbed ? ', #embed, #embed-tabindex-0, #embed-svg, #embed-tabindex-svg' : ', #embed-svg, #embed-tabindex-svg')
           + (supports.canFocusAudioWithoutControls ? ', #audio' : '')
           + ', #audio-controls'
           + ', #input, #input-tabindex--1, #input-disabled'
@@ -124,6 +125,7 @@ define([
         var result = queryFocusable({
           strategy: 'all',
         });
+        var canTestVideoEmbed = Boolean(document.getElementById('embed'));
         var expected = '#tabindex--1, #tabindex-0, #tabindex-1'
           + (supports.canFocusInvalidTabindex ? ', #tabindex-bad' : '')
           + ', #link, #link-tabindex--1'
@@ -131,7 +133,7 @@ define([
           + (supports.canFocusAreaWithoutHref ? ', #image-map-area-nolink' : '')
           + (supports.canFocusObjectSvg ? ', #object-svg, #object-tabindex-svg' : '')
           + ', #svg-link'
-          + ', #embed, #embed-tabindex-0, #embed-svg, #embed-tabindex-svg'
+          + (canTestVideoEmbed ? ', #embed, #embed-tabindex-0, #embed-svg, #embed-tabindex-svg' : ', #embed-svg, #embed-tabindex-svg')
           + (supports.canFocusAudioWithoutControls ? ', #audio' : '')
           + ', #audio-controls'
           + ', #input, #input-tabindex--1'


### PR DESCRIPTION
This PR contains:

* fixing `query/tabsequence.sort-area` to use WebKit-safe way of CSS.escape polyfill (which got lost because it was in a PR parallel to [812d134](https://github.com/medialize/ally.js/commit/812d1346558d29dfd7e455abf67d5027e01bb751))
* test: avoid `<embed>` with video content in Safari (to get around QuickTime interfering with the test)
* test: activate Safari 6.2 - 9 on BrowserStack
* test: update Chrome and Firefox on BrowserStack

Activating IE12 / Edge12 is blocked by theintern/intern#555.
