### PR TITLE
Fix/pointer focus children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ The following lists show the changes to the library grouped by domain.
 
 #### Browser Behavior
 
-* fixing [`ally.fix.pointerFocusChildren`]([ally/fix/pointer-focus-children]) to use focus identity exceptions - [issue #103](https://github.com/medialize/ally.js/issues/103)
+* fixing [`ally.fix.pointerFocusChildren`][ally/fix/pointer-focus-children] to use focus identity exceptions - [issue #103](https://github.com/medialize/ally.js/issues/103)
+* fixing [`ally.fix.pointerFocusInput`][ally/fix/pointer-focus-input] to properly target nested content of `<button>` and `<label>` elements
 
 #### Focusable detection
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The following lists show the changes to the library grouped by domain.
 * upgrading to [platform.js](https://github.com/bestiejs/platform.js) v1.3.1
 * adding [domtokenlist-shim](https://github.com/jwilsson/domtokenlist) for IE9
 
+#### Browser Behavior
+
+* fixing [`ally.fix.pointerFocusChildren`]([ally/fix/pointer-focus-children]) to use focus identity exceptions - [issue #103](https://github.com/medialize/ally.js/issues/103)
+
 #### Focusable detection
 
 * changing [`ally.is.focusRelevant`][ally/is/focus-relevant] and [`ally.is.focusable`][ally/is/focusable] to regard `<keygen>` and `<embed>` focus-relevant but *not* focusable - [issue #82](https://github.com/medialize/ally.js/issues/82)

--- a/docs/api/fix/pointer-focus-children.md
+++ b/docs/api/fix/pointer-focus-children.md
@@ -64,6 +64,11 @@ A [`<service>`](../concepts.md#Service) interface, providing the `handle.disenga
 * **EXAMPLE:** [`ally.fix.pointerFocusChildren` Example](./pointer-focus-children.example.html)
 
 
+## Changes
+
+* Since `v#master` the module is executed on `mousdown` instead of `pointerdown`.
+
+
 ## Notes
 
 * **NOTE:** CSS Transitions are disabled for any styles changed on `mousedown` (and `:active`) on the erroneously focusable child elements.

--- a/docs/api/fix/pointer-focus-input.md
+++ b/docs/api/fix/pointer-focus-input.md
@@ -48,6 +48,11 @@ A [`<service>`](../concepts.md#Service) interface, providing the `handle.disenga
 * **EXAMPLE:** [`ally.fix.pointerFocusInput` Example](./pointer-focus-input.example.html)
 
 
+## Changes
+
+* Since `v#master` nested elements of `<button>` and `<label>` are targeted properly.
+
+
 ## Notes
 
 * **NOTE:** In Firefox the `<label>` element causes form fields to get focus upon being clicked, even if the form field itself would not get focus because of the ominous platform conventions.

--- a/docs/api/get/focus-target.md
+++ b/docs/api/get/focus-target.md
@@ -39,6 +39,7 @@ var element = ally.get.focusTarget({
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | context | [`<selector>`](../concepts.md#Selector) | *required* | The element to start searching from. The first element of a collection is used. |
+| except | [`<focus identification exception>`](../concepts.md#Focus-identification-exceptions) | `{}` | The Element to test. |
 
 ### Returns
 
@@ -55,6 +56,7 @@ var element = ally.get.focusTarget({
 ## Changes
 
 * Since `v#master` elements redirecting focus return their target elements.
+* Since `v#master` exceptions can be passed through to `ally.is.focusable` via the `except` argument.
 
 
 ## Notes

--- a/src/fix/pointer-focus-input.js
+++ b/src/fix/pointer-focus-input.js
@@ -9,7 +9,10 @@
   option `accessibility.mouse_focuses_formcontrol` in about:config
 */
 
+import polyfillElementPrototypeMatches from '../prototype/element.prototype.matches';
+import getFocusTarget from '../get/focus-target';
 import decorateContext from '../util/decorate-context';
+import getWindow from '../util/get-window';
 import platform from '../util/platform';
 
 let engage;
@@ -20,28 +23,47 @@ const relevantToCurrentBrowser = platform.is.OSX && (platform.is.GECKO || platfo
 if (!relevantToCurrentBrowser) {
   engage = function() {};
 } else {
-  const inputPattern = /^(input|button)$/;
-
   const handleMouseDownEvent = function(event) {
-    if (event.defaultPrevented || !event.target.nodeName.toLowerCase().match(inputPattern)) {
-      // abort if the mousedown event was cancelled
+    const _window = getWindow(event.target);
+    polyfillElementPrototypeMatches(_window);
+    if (event.defaultPrevented || !event.target.matches('input, button, button *')) {
+      // abort if the mousedown event was cancelled,
+      // or we're not dealing with an affected form control
+      return;
+    }
+
+    const target = getFocusTarget({
+      context: event.target,
+    });
+
+    if (!target) {
       return;
     }
 
     // we need to set focus AFTER the mousedown finished, otherwise WebKit will ignore the call
     (window.setImmediate || window.setTimeout)(function() {
-      event.target.focus();
+      target.focus();
     });
   };
 
   const handleMouseUpEvent = function(event) {
-    if (event.defaultPrevented || event.target.nodeName.toLowerCase() !== 'label') {
-      // abort if the mouseup event was cancelled
+    const _window = getWindow(event.target);
+    polyfillElementPrototypeMatches(_window);
+    if (event.defaultPrevented || !event.target.matches('label, label *')) {
+      // abort if the mouseup event was cancelled,
+      // or we're not dealing with a <label>
       return;
     }
 
-    // <label> will redirect focus to the appropriate input element on its own
-    event.target.focus();
+    const target = getFocusTarget({
+      context: event.target,
+    });
+
+    if (!target) {
+      return;
+    }
+
+    target.focus();
   };
 
   engage = function(element) {

--- a/src/get/focus-target.js
+++ b/src/get/focus-target.js
@@ -8,7 +8,7 @@ import getParents from '../get/parents';
 import isFocusable from '../is/focusable';
 import contextToElement from '../util/context-to-element';
 
-export default function({context} = {}) {
+export default function({context, except} = {}) {
   const element = contextToElement({
     message: 'get/focus-target requires valid options.context',
     context,
@@ -16,8 +16,20 @@ export default function({context} = {}) {
 
   let result = null;
   const getTarget = function(_element) {
-    result = isFocusable(_element) && _element
-      || getFocusRedirectTarget({ context: _element, skipFocusable: true });
+    const focusable = isFocusable.rules({
+      context: _element,
+      except,
+    });
+
+    if (focusable) {
+      result = _element;
+      return true;
+    }
+
+    result = getFocusRedirectTarget({
+      context: _element,
+      skipFocusable: true,
+    });
 
     return Boolean(result);
   };

--- a/test/browserstack.js
+++ b/test/browserstack.js
@@ -22,7 +22,7 @@ define([
     // disabled because of https://github.com/theintern/intern/issues/555
     // { browser: 'Edge', browser_version: '12.0', os: 'WINDOWS', os_version: '10', platform: 'WIN', browserName: 'Edge12' },
     { browser: 'IE', browser_version: '11', os: 'WINDOWS', os_version: '8.1', platform: 'WIN', browserName: 'IE11' },
-    { browser: 'IE', browser_version: '10', os: 'WINDOWS', os_version: '8', platform: 'WIN', browserName: 'IE10' },
+    { browser: 'IE', browser_version: '10', os: 'WINDOWS', os_version: '8', platform: 'WIN', browserName: 'IE10', nativeEvents: true },
     { browser: 'IE', browser_version: '9', os: 'WINDOWS', os_version: '7', platform: 'WIN', browserName: 'IE9' },
 
     { browser: 'Firefox', browser_version: '42', os: 'WINDOWS', os_version: '8.1', platform: 'WIN', browserName: 'Firefox 42' },

--- a/test/functional/fix.pointer-focus-children.test.js
+++ b/test/functional/fix.pointer-focus-children.test.js
@@ -2,45 +2,70 @@ define([
   'intern!object',
   'intern/chai!expect',
   'require',
-], function(registerSuite, expect, require) {
+  'intern/dojo/node!leadfoot/helpers/pollUntil',
+], function(registerSuite, expect, require, pollUntil) {
 
   registerSuite(function() {
+    var timeout = 120000;
 
-    // function isRelevantToBrowser() {
-    //   var userAgent = window.navigator.userAgent;
-    //   // This fix is only relevant to IE10 (Trident/6) and IE11 (Trident/7)
-    //   return userAgent.indexOf('Trident/6') !== -1 || userAgent.indexOf('Trident/7') !== -1;
-    // }
+    function makeFocusClickTest(prefix, fails) {
+      return function() {
+        this.timeout = timeout;
+        return this.remote
+
+          // This fix is only relevant to IE10 (Trident/6) and IE11 (Trident/7)
+          .then(pollUntil('return window.platform'))
+          .then(function(platform) {
+            if (!platform.is.IE10 && !platform.is.IE11) {
+              this.skip('irrelevant to current browser');
+            }
+          }.bind(this))
+
+          // make sure we're failing without the fix
+          .findById(prefix + 'fail-source')
+            .click()
+            .end()
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            expect(activeElementId).to.equal(fails ? (prefix + 'fail-source') : (prefix + 'fail-target'));
+          })
+
+          // I have no clue why, but IE11 needs this for
+          // the next click to actually focus something.
+          .findByCssSelector('body')
+            .click()
+            .end()
+          .sleep(500)
+
+          // make sure we're not failing with the fix
+          .findById(prefix + 'fixed-source')
+            .click()
+            .end()
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            expect(activeElementId).to.equal(prefix + 'fixed-target');
+          });
+      };
+    }
 
     return {
       name: 'fix/pointer-focus-children',
 
-      firstTest: function() {
-        // TODO: find out how we can identify the browser we're running on
-        // if (!isRelevantToBrowser()) {
-        //   this.skip('Current browser is not affected');
-        // }
-
+      before: function() {
         return this.remote
           .get(require.toUrl('test/pages/fix.pointer-focus-children.test.html'))
-          .setFindTimeout(5000)
-
-          .findById('target-fail')
-            .click()
-            .end()
-          .getActiveElement().getProperty('id')
-          .then(function(activeElementId) {
-            expect(activeElementId).to.equal('target-fail');
-          })
-
-          .findById('target-fixed')
-            .click()
-            .end()
-          .getActiveElement().getProperty('id')
-          .then(function(activeElementId) {
-            expect(activeElementId).to.equal('target-fixed');
-          });
+          .setPageLoadTimeout(timeout)
+          .setFindTimeout(timeout)
+          .setExecuteAsyncTimeout(timeout);
       },
+
+      'div[tabindex="-1"] > span': makeFocusClickTest('normal-', false),
+      'div[tabindex="-1"]{flexbox} > span': makeFocusClickTest('child-', true),
+      'div[tabindex="-1"] > div{flexbox} > span': makeFocusClickTest('nested-', true),
+      'input + label': makeFocusClickTest('redirect-', false),
+      'input + label{flexbox} > span': makeFocusClickTest('redirect-flexed-', false),
     };
   });
 });

--- a/test/functional/fix.pointer-focus-input.test.js
+++ b/test/functional/fix.pointer-focus-input.test.js
@@ -1,0 +1,78 @@
+define([
+  'intern!object',
+  'intern/chai!expect',
+  'require',
+  'intern/dojo/node!leadfoot/helpers/pollUntil',
+], function(registerSuite, expect, require, pollUntil) {
+
+  registerSuite(function() {
+    var timeout = 120000;
+
+    function makeFocusClickTest(prefix, hasTarget) {
+      return function() {
+        this.timeout = timeout;
+        return this.remote
+
+          // This fix is only relevant to Safari and Firefox on OSX
+          .then(pollUntil('return window.platform'))
+          .then(function(platform) {
+            if (!platform.is.OSX || !platform.is.GECKO && !platform.is.WEBKIT) {
+              this.skip('irrelevant to current browser');
+            }
+          }.bind(this))
+
+          // make sure we're failing without the fix
+          .findById(prefix + 'fail-source')
+            .click()
+            .end()
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            var expected = hasTarget ? (prefix + 'fail-target') : (prefix + 'fail-source');
+            if (activeElementId === expected) {
+              this.skip('Element focused naturally');
+            }
+          }.bind(this))
+
+          // I have no clue why, but IE11 needs this for
+          // the next click to actually focus something.
+          .findByCssSelector('body')
+            .click()
+            .end()
+          .sleep(500)
+
+          // make sure we're not failing with the fix
+          .findById(prefix + 'fixed-source')
+            .click()
+            .end()
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            var expected = hasTarget ? (prefix + 'fixed-target') : (prefix + 'fixed-source');
+            expect(activeElementId).to.equal(expected);
+          });
+      };
+    }
+
+    return {
+      name: 'fix/pointer-focus-input',
+
+      before: function() {
+        return this.remote
+          .get(require.toUrl('test/pages/fix.pointer-focus-input.test.html'))
+          .setPageLoadTimeout(timeout)
+          .setFindTimeout(timeout)
+          .setExecuteAsyncTimeout(timeout);
+      },
+
+      '<button>': makeFocusClickTest('button-', false),
+      '<button><span>': makeFocusClickTest('nested-button-', true),
+      '<input type="button">': makeFocusClickTest('input-button-', false),
+      '<input type="checkbox">': makeFocusClickTest('checkbox-', false),
+      '<input type="checkbox"> clicking on <label>': makeFocusClickTest('labeled-checkbox-', true),
+      '<input type="checkbox"> clicking on <label><span>': makeFocusClickTest('nested-labeled-checkbox-', true),
+      '<input type="range">': makeFocusClickTest('slider-', false),
+      '≤input type="radio">': makeFocusClickTest('radio-', false),
+    };
+  });
+});

--- a/test/functional/fix.pointer-focus-parent.test.js
+++ b/test/functional/fix.pointer-focus-parent.test.js
@@ -1,0 +1,74 @@
+define([
+  'intern!object',
+  'intern/chai!expect',
+  'require',
+  'intern/dojo/node!leadfoot/helpers/pollUntil',
+], function(registerSuite, expect, require, pollUntil) {
+
+  registerSuite(function() {
+    var timeout = 120000;
+
+    function makeFocusClickTest(prefix, hasTarget) {
+      return function() {
+        this.timeout = timeout;
+        return this.remote
+
+          // This fix is only relevant to WebKit
+          .then(pollUntil('return window.platform'))
+          .then(function(platform) {
+            if (!platform.is.WEBKIT) {
+              this.skip('irrelevant to current browser');
+            }
+          }.bind(this))
+
+          // make sure we're failing without the fix
+          .findById(prefix + 'fail-source')
+            .click()
+            .end()
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            var expected = hasTarget ? (prefix + 'fail-target') : (prefix + 'fail-source');
+            if (activeElementId === expected) {
+              this.skip('Element focused naturally');
+            }
+          }.bind(this))
+
+          // I have no clue why, but IE11 needs this for
+          // the next click to actually focus something.
+          .findByCssSelector('body')
+            .click()
+            .end()
+          .sleep(500)
+
+          // make sure we're not failing with the fix
+          .findById(prefix + 'fixed-source')
+            .click()
+            .end()
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            var expected = hasTarget ? (prefix + 'fixed-target') : (prefix + 'fixed-source');
+            expect(activeElementId).to.equal(expected);
+          });
+      };
+    }
+
+    return {
+      name: 'fix/pointer-focus-parent',
+
+      before: function() {
+        return this.remote
+          .get(require.toUrl('test/pages/fix.pointer-focus-parent.test.html'))
+          .setPageLoadTimeout(timeout)
+          .setFindTimeout(timeout)
+          .setExecuteAsyncTimeout(timeout);
+      },
+
+      // '<button>': makeFocusClickTest('button-', false),
+      // '<button><span>': makeFocusClickTest('nested-button-', true),
+      '<a href="">': makeFocusClickTest('link-', false),
+      // '<span tabindex="-1">': makeFocusClickTest('focusable-', false),
+    };
+  });
+});

--- a/test/intern.js
+++ b/test/intern.js
@@ -137,6 +137,7 @@ define([
       'test/functional/maintain.tab-focus.test.js',
       'test/functional/fix.pointer-focus-children.test.js',
       'test/functional/fix.pointer-focus-input.test.js',
+      'test/functional/fix.pointer-focus-parent.test.js',
     ],
 
     // A regular expression matching URLs to files that should not be included in code coverage analysis

--- a/test/intern.js
+++ b/test/intern.js
@@ -135,6 +135,7 @@ define([
     functionalSuites: [
       'test/functional/intern.events.test.js',
       'test/functional/maintain.tab-focus.test.js',
+      'test/functional/fix.pointer-focus-children.test.js',
     ],
 
     // A regular expression matching URLs to files that should not be included in code coverage analysis

--- a/test/intern.js
+++ b/test/intern.js
@@ -136,6 +136,7 @@ define([
       'test/functional/intern.events.test.js',
       'test/functional/maintain.tab-focus.test.js',
       'test/functional/fix.pointer-focus-children.test.js',
+      'test/functional/fix.pointer-focus-input.test.js',
     ],
 
     // A regular expression matching URLs to files that should not be included in code coverage analysis

--- a/test/pages/fix.pointer-focus-children.test.html
+++ b/test/pages/fix.pointer-focus-children.test.html
@@ -16,18 +16,86 @@
       -ms-flex: 1 1 100px;
           flex: 1 1 10px;
     }
+
+    body :focus {
+      outline: 1px solid red;
+    }
   </style>
 </head>
 <body>
+  <h1>Unhandled Flexbox Click Focus</h1>
 
-  <div id="parent-fail" tabindex="-1" class="flex">
-    <span id="target-fail">one</span>
+  <h2>Normal</h2>
+  <div id="normal-fail-target" tabindex="-1">
+    <span id="normal-fail-source">target</span>
+  </div>
+
+  <h2>Flexed Child</h2>
+  <div id="child-fail-target" tabindex="-1" class="flex">
+    <span id="child-fail-source">target</span>
     <span>two</span>
   </div>
 
-  <div id="parent-fixed" tabindex="-1" class="flex">
-    <span id="target-fixed">one</span>
-    <span>two</span>
+  <h2>Flexed Descendant</h2>
+  <div id="nested-fail-target" tabindex="-1">
+    <div id="nested-fail-wrapper" class="flex">
+      <span id="nested-fail-source">target</span>
+      <span>two</span>
+    </div>
+  </div>
+
+  <h2>Normal Redirect</h2>
+  <div id="redirect-fail-wrapper">
+    <input id="redirect-fail-target">
+    <label for="redirect-fail-target" id="redirect-fail-source">target</label>
+  </div>
+
+  <h2>Flexed Redirect</h2>
+  <div id="redirect-flexed-fail-wrapper">
+    <input id="redirect-flexed-fail-target">
+    <label for="redirect-flexed-fail-target" class="flex">
+      <span id="redirect-flexed-fail-source">target</span>
+      <span>two</span>
+    </label>
+  </div>
+
+  <hr>
+
+  <h1>Handled Flexbox Click Focus</h1>
+  <div id="engage-fix">
+    <h2>Normal</h2>
+    <div id="normal-fixed-target" tabindex="-1">
+      <span id="normal-fixed-source">target</span>
+    </div>
+
+    <h2>Flexed Child</h2>
+    <div id="child-fixed-target" tabindex="-1" class="flex">
+      <span id="child-fixed-source">target</span>
+      <span>two</span>
+    </div>
+
+    <h2>Flexed Descendant</h2>
+    <div id="nested-fixed-target" tabindex="-1">
+      <div id="nested-fixed-wrapper" class="flex">
+        <span id="nested-fixed-source">target</span>
+        <span>two</span>
+      </div>
+    </div>
+
+    <h2>Normal Redirect</h2>
+    <div id="redirect-fixed-wrapper">
+      <input id="redirect-fixed-target">
+      <label for="redirect-fixed-target" id="redirect-fixed-source">target</label>
+    </div>
+
+    <h2>Flexed Redirect</h2>
+    <div id="redirect-flexed-fixed-wrapper">
+      <input id="redirect-flexed-fixed-target">
+      <label for="redirect-flexed-fixed-target" class="flex">
+        <span id="redirect-flexed-fixed-source">target</span>
+        <span>two</span>
+      </label>
+    </div>
   </div>
 
   <script src="../../node_modules/requirejs/require.js"></script>
@@ -37,13 +105,20 @@
         ally: '../../dist/amd',
         // shims required by ally.js
         'array.prototype.findindex': '../../node_modules/array.prototype.findindex/index',
+        'domtokenlist-shim': '../../node_modules/domtokenlist-shim/dist/domtokenlist',
         'css.escape': '../../node_modules/css.escape/css.escape',
+        'platform': '../../node_modules/platform/platform',
       }
     });
 
-    require(['ally/fix/pointer-focus-children'], function(fixPointerFocusChildren) {
+    require([
+      'ally/util/platform',
+      'ally/fix/pointer-focus-children',
+    ], function(platform, fixPointerFocusChildren) {
+      window.platform = platform;
+
       fixPointerFocusChildren({
-        context: '#parent-fixed',
+        context: '#engage-fix',
       });
     });
   </script>

--- a/test/pages/fix.pointer-focus-input.test.html
+++ b/test/pages/fix.pointer-focus-input.test.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Fix Pointer Focus Input Browser Bug</title>
+  <style>
+    .flex {
+      display: -webkit-flexbox;
+      display:     -ms-flexbox;
+      display:            flex;
+      width: 300px;
+    }
+
+    .flex > span {
+      display: block;
+      -ms-flex: 1 1 100px;
+          flex: 1 1 10px;
+    }
+
+    body :focus {
+      outline: 1px solid red;
+    }
+  </style>
+</head>
+<body>
+  <h1>Unhandled Input Focus</h1>
+
+  <h2>Button</h2>
+  <button type="button" id="button-fail-source">button</button>
+
+  <h2>Button Nested</h2>
+  <button type="button" id="nested-button-fail-target">
+    <span id="nested-button-fail-source">button</span>
+  </button>
+
+  <h2>Input Button</h2>
+  <input type="button" id="input-button-fail-source" value="button">
+
+  <h2>Checkbox</h2>
+  <input type="checkbox" id="checkbox-fail-source">
+
+  <h2>Checkbox Label</h2>
+  <input type="checkbox" id="labeled-checkbox-fail-target">
+  <label for="labeled-checkbox-fail-target" id="labeled-checkbox-fail-source">target</label>
+
+  <h2>Checkbox Label Nested</h2>
+  <input type="checkbox" id="nested-labeled-checkbox-fail-target">
+  <label for="nested-labeled-checkbox-fail-target">
+    <span id="nested-labeled-checkbox-fail-source">target</span>
+  </label>
+
+  <h2>Slider</h2>
+  <input type="range" min="0" max="100" id="slider-fail-source">
+
+  <h2>Radio</h2>
+  <input type="radio" name="natural" id="radio-fail-source">
+  <input type="radio" name="natural">
+
+  <hr>
+
+  <h1>Handled Input Focus</h1>
+  <div id="engage-fix">
+    <h2>Button</h2>
+    <button type="button" id="button-fixed-source">button</button>
+
+    <h2>Button Nested</h2>
+    <button type="button" id="nested-button-fixed-target">
+      <span id="nested-button-fixed-source">button</span>
+    </button>
+
+    <h2>Input Button</h2>
+    <input type="button" id="input-button-fixed-source" value="button">
+
+    <h2>Checkbox</h2>
+    <input type="checkbox" id="checkbox-fixed-source">
+
+    <h2>Checkbox Label</h2>
+    <input type="checkbox" id="labeled-checkbox-fixed-target">
+    <label for="labeled-checkbox-fixed-target" id="labeled-checkbox-fixed-source">target</label>
+
+    <h2>Checkbox Label Nested</h2>
+    <input type="checkbox" id="nested-labeled-checkbox-fixed-target">
+    <label for="nested-labeled-checkbox-fixed-target">
+      <span id="nested-labeled-checkbox-fixed-source">target</span>
+    </label>
+
+    <h2>Slider</h2>
+    <input type="range" min="0" max="100" id="slider-fixed-source">
+
+    <h2>Radio</h2>
+    <input type="radio" name="natural" id="radio-fixed-source">
+    <input type="radio" name="natural">
+  </div>
+
+  <script src="../../node_modules/requirejs/require.js"></script>
+  <script>
+    require.config({
+      paths: {
+        ally: '../../dist/amd',
+        // shims required by ally.js
+        'array.prototype.findindex': '../../node_modules/array.prototype.findindex/index',
+        'domtokenlist-shim': '../../node_modules/domtokenlist-shim/dist/domtokenlist',
+        'css.escape': '../../node_modules/css.escape/css.escape',
+        'platform': '../../node_modules/platform/platform',
+      }
+    });
+
+    require([
+      'ally/util/platform',
+      'ally/fix/pointer-focus-input',
+    ], function(platform, fixPointerFocusInput) {
+      window.platform = platform;
+
+      fixPointerFocusInput({
+        context: '#engage-fix',
+      });
+    });
+  </script>
+</body>
+</html>

--- a/test/pages/fix.pointer-focus-parent.test.html
+++ b/test/pages/fix.pointer-focus-parent.test.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Fix Pointer Focus Parent Browser Bug</title>
+  <style>
+    .flex {
+      display: -webkit-flexbox;
+      display:     -ms-flexbox;
+      display:            flex;
+      width: 300px;
+    }
+
+    .flex > span {
+      display: block;
+      -ms-flex: 1 1 100px;
+          flex: 1 1 10px;
+    }
+
+    body :focus {
+      outline: 1px solid red;
+    }
+  </style>
+</head>
+<body>
+  <h1>Unhandled Parent Focus</h1>
+
+  <!-- would fail because buttons may not take focus, see fix/pointer-focus-input
+  <h2>Button</h2>
+  <div tabindex="-1" id="button-fail-parent">
+    <button type="button" id="button-fail-source">button</button>
+  </div>
+
+  <h2>Nested Button</h2>
+  <div tabindex="-1" id="nested-button-fail-parent">
+    <button type="button" id="nested-button-fail-target">
+      <span id="nested-button-fail-source">button</span>
+    </button>
+  </div>
+  -->
+
+  <h2>Link</h2>
+  <div tabindex="-1" id="link-fail-parent">
+    <a href="#void" id="link-fail-source">target</a>
+  </div>
+
+  <!-- does not fail because the target element has a tabindex attribute
+  <h2>Focusable</h2>
+  <div tabindex="-1" id="focusable-fail-parent">
+    <span tabindex="-1" id="focusable-fail-source">target</span>
+  </div>
+  -->
+
+  <hr>
+
+  <h1>Handled Parent Focus</h1>
+  <div id="engage-fix">
+
+    <!-- would fail because buttons may not take focus, see fix/pointer-focus-input
+    <h2>Button</h2>
+    <div tabindex="-1" id="button-fixed-parent">
+      <button type="button" id="button-fixed-source">button</button>
+    </div>
+
+    <h2>Nested Button</h2>
+    <div tabindex="-1" id="nested-button-fixed-parent">
+      <button type="button" id="nested-button-fixed-target">
+        <span id="nested-button-fixed-source">button</span>
+      </button>
+    </div>
+    -->
+
+    <h2>Link</h2>
+    <div tabindex="-1" id="link-fixed-parent">
+      <a href="#void" id="link-fixed-source">target</a>
+    </div>
+
+    <!-- does not fail because the target element has a tabindex attribute
+    <h2>Focusable</h2>
+    <div tabindex="-1" id="focusable-fixed-parent">
+      <span tabindex="-1" id="focusable-fixed-source">target</span>
+    </div>
+    -->
+  </div>
+
+  <script src="../../node_modules/requirejs/require.js"></script>
+  <script>
+    require.config({
+      paths: {
+        ally: '../../dist/amd',
+        // shims required by ally.js
+        'array.prototype.findindex': '../../node_modules/array.prototype.findindex/index',
+        'domtokenlist-shim': '../../node_modules/domtokenlist-shim/dist/domtokenlist',
+        'css.escape': '../../node_modules/css.escape/css.escape',
+        'platform': '../../node_modules/platform/platform',
+      }
+    });
+
+    require([
+      'ally/util/platform',
+      'ally/fix/pointer-focus-parent',
+      'ally/fix/pointer-focus-input',
+    ], function(platform, fixPointerFocusParent, fixPointerFocusInput) {
+      window.platform = platform;
+
+      fixPointerFocusParent({
+        context: '#engage-fix',
+      });
+
+      fixPointerFocusParent({
+        context: '#engage-both-fix',
+      });
+
+      fixPointerFocusInput({
+        context: '#engage-both-fix',
+      });
+    });
+  </script>
+</body>
+</html>

--- a/test/unit/get.focus-target.test.js
+++ b/test/unit/get.focus-target.test.js
@@ -28,6 +28,10 @@ define([
             '<span id="none" data-label="none-inner">nested</span>',
           '</div>',
           '<label id="label-nested">label <input id="label-nested-target"></label>',
+          '<div id="flexbox-container" tabindex="-1" ',
+            'style="display: -webkit-flexbox; display: -ms-flexbox; display: flex; width: 300px;">',
+            '<div id="flexbox-child">flexed</span>',
+          '</div>',
           /*eslint-enable indent */
         ]);
       },
@@ -75,6 +79,17 @@ define([
         });
 
         expect(target.id).to.equal('label-nested-target');
+      },
+      'flexbox parent': function() {
+        var target = getFocusTarget({
+          context: '#flexbox-child',
+          except: {
+            flexbox: true,
+            scrollable: true,
+          },
+        });
+
+        expect(target.id).to.equal('flexbox-container');
       },
     };
   });


### PR DESCRIPTION
covers #103, contains commits from #102 

* [x] allow `get/focus-target` to pass focus identity exceptions to `is/focusable`
* [x] make `fix/pointer-focus-children` ignore flexbox on target identification
* [x] add functional test to gover this automatically
* [x] make sure that a click on `#target` lands on `#gustav` in  `<div tabindex="-1" id="gustav"><div style="…flexbox–"><div id="target">`
* [x] adding functional test for `fix/pointer-focus-input`
* [x] adding functional test for `fix/pointer-focus-parent`
