### PR TITLE
Issue/63 maintain document focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The following lists show the changes to the library grouped by domain.
 
 * changing [`ally.when.key`][ally/when/key] to handle modifier keys and respect `context` and `filter` options - [issue #59](https://github.com/medialize/ally.js/issues/59)
 * changing [`ally.map.keycode`][ally/map/keycode] to provide alphanumeric keys and aliasing
+* adding [`ally.maintain.tabFocus`][ally/maintain/tab-focus] to trap <kbd>TAB</kbd> focus in the tabsequence - [issue #63](https://github.com/medialize/ally.js/issues/63)
 
 #### Internals
 
@@ -242,6 +243,7 @@ Version `1.0.0` is a complete rewrite from the the early `0.0.x` releases, there
 [ally/is/visible]: http://allyjs.io/api/is/visible.html
 [ally/maintain/disabled]: http://allyjs.io/api/maintain/disabled.html
 [ally/maintain/hidden]: http://allyjs.io/api/maintain/hidden.html
+[ally/maintain/tab-focus]: http://allyjs.io/api/maintain/tab-focus.html
 [ally/map/attribute]: http://allyjs.io/api/map/attribute.html
 [ally/map/keycode]: http://allyjs.io/api/map/keycode.html
 [ally/observe/interaction-type]: http://allyjs.io/api/observe/interaction-type.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The following lists show the changes to the library grouped by domain.
 * fixing [`ally.get.focusTarget`][ally/get/focus-target] to resolve elements redirecting focus to other elements
 * fixing [`ally.is.tabbable`][ally/is/tabbable] to consider `<iframe>` elements not tabbable
 * fixing [`ally.is.onlyTabbable`][ally/is/only-tabbable] to not consider `<object>` elements only tabbable anymore
+* adding [`ally.is.activeElement`][ally/is/active-element] to identify if an element is the activeElement within its context
 
 
 #### Keyboard support
@@ -229,6 +230,7 @@ Version `1.0.0` is a complete rewrite from the the early `0.0.x` releases, there
 [ally/get/parents]: http://allyjs.io/api/get/parents.html
 [ally/get/shadow-host-parents]: http://allyjs.io/api/get/shadow-host-parents.html
 [ally/get/shadow-host]: http://allyjs.io/api/get/shadow-host.html
+[ally/is/active-element]: http://allyjs.io/api/is/active-element.html
 [ally/is/disabled]: http://allyjs.io/api/is/disabled.html
 [ally/is/focus-relevant]: http://allyjs.io/api/is/focus-relevant.html
 [ally/is/focusable]: http://allyjs.io/api/is/focusable.html

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -30,6 +30,7 @@ While it's best to use standardized features and leave browsers to figure things
 
 * [`ally.maintain.disabled`](maintain/disabled.md) renders elements inert to prevent any user interaction
 * [`ally.maintain.hidden`](maintain/hidden.md) sets `aria-hidden="true"` on insignificant branches
+* [`ally.maintain.tabFocus`](maintain/tab-focus.md) traps <kbd>TAB</kbd> focus in the tabsequence
 
 
 ## Finding elements

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -46,6 +46,7 @@ In order to work with focusable elements, we must first know which elements we'r
 
 Unlike any other ally modules, these components do not take take [`options.context` argument](concepts.md#Single-options-argument), but expect the `element` as first argument, allowing easy use in [`.filter()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter). See [what does "focusable" mean?](../what-is-focusable.md) for a differentiation.
 
+* [`ally.is.activeElement`](is/active-element.md) returns true if the element is the activeElement of its host context, i.e. its document, iFrame or ShadowHost
 * [`ally.is.disabled`](is/disabled.md) returns true if the element is `:disabled`
 * [`ally.is.focusRelevant`](is/focus-relevant.md) returns true if the element is considered theoretically focusable
 * [`ally.is.focusable`](is/focusable.md) returns true if the element is considered focusable by script

--- a/docs/api/is/active-element.md
+++ b/docs/api/is/active-element.md
@@ -1,0 +1,56 @@
+---
+layout: doc-api.html
+tags: argument-list, shadow-dom
+---
+
+# ally.is.activeElement
+
+Determines if an element is the activeElement of its host context, i.e. its document, iFrame or ShadowHost.
+
+
+## Description
+
+
+## Usage
+
+```js
+var element = document.getElementById('victim');
+var isActiveElement = ally.is.activeElement(element);
+```
+
+### Arguments
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| element | [`HTMLElement`](https://developer.mozilla.org/en/docs/Web/API/HTMLElement) | *required* | The Element to test. |
+
+### Returns
+
+Boolean, `true` if the element is the activeElement of its host context.
+
+### Throws
+
+[`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) if `element` argument is not of type `HTMLElement`.
+
+
+## Examples
+
+
+## Changes
+
+* Added in `v#master`.
+
+
+## Notes
+
+
+
+## Related resources
+
+
+## Contributing
+
+* [module source](https://github.com/medialize/ally.js/blob/master/src/is/active-element.js)
+* [document source](https://github.com/medialize/ally.js/blob/master/docs/api/is/active-element.md)
+* [unit test](https://github.com/medialize/ally.js/blob/master/test/unit/is.active-element.test.js)
+

--- a/docs/api/maintain/tab-focus.example.html
+++ b/docs/api/maintain/tab-focus.example.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>ally.maintain.hidden Example</title>
+  <link rel="jsbin" href="">
+  <style id="example-css">
+    :disabled,
+    [data-ally-disabled] {
+      outline: 1px solid red;
+      opacity: 0.5;
+    }
+  </style>
+</head>
+<body>
+
+<article id="example-introduction">
+  <h1><code>ally.maintain.tabFocus</code> Example</h1>
+
+  <p>
+    Use the <code>trap focus</code> button to engage <code>ally.maintain.disabled</code> and <code>ally.maintain.tabFocus</code> so that only the input elements <em>first</em>, <em>second</em> and <em>third</em> can be focused by pressing the <kbd>Tab</kbd> key.
+    Press the <kbd>Escape</kbd> key to stop trapping focus.
+    Note that the disabled elements are visualized with reduced opacity and a red border only for this demo.
+  </p>
+</article>
+
+<div id="example-html">
+  <main>
+    <button id="toggle" type="button">trap focus</button>
+
+    <hr>
+
+    <input type="text" value="before">
+
+    <div id="container">
+      <input type="text" value="second" tabindex="0">
+      <input type="text" value="not keyboard focusable" tabindex="-1">
+      <input type="text" value="first" tabindex="1" id="start-focus">
+      <input type="text" value="third" tabindex="0">
+    </div>
+
+    <input type="text" value="after">
+
+  </main>
+</div>
+
+<script src="https://cdn.jsdelivr.net/ally.js/1.0.1/ally.min.js"></script>
+
+<script id="example-js">
+  var handle;
+
+  var wrapper = document.getElementById('example-html');
+  var container = document.getElementById('container');
+  var toggle = document.getElementById('toggle');
+
+  toggle.addEventListener('click', function() {
+    handle = ally.maintain.tabFocus({
+      context: container,
+    });
+
+    ally.when.key({
+      escape: function(event, disengage) {
+        handle.disengage();
+        handle = null;
+        toggle.focus();
+        disengage();
+      },
+    });
+
+    document.getElementById('start-focus').focus();
+  });
+
+</script>
+
+</body>
+</html>

--- a/docs/api/maintain/tab-focus.md
+++ b/docs/api/maintain/tab-focus.md
@@ -1,0 +1,66 @@
+---
+layout: doc-api.html
+tags: service, argument-object
+---
+
+# ally.maintain.tabFocus
+
+Traps <kbd>TAB</kbd> focus in the tabsequence to prevent the browser from shifting focus to its UI (e.g. the location bar).
+
+
+## Description
+
+`ally.maintain.tabFocus` intercepts the keyboard events for <kbd>Tab</kbd> and <kbd>Shift Tab</kbd> in order to make sure the element receiving focus is part of the context element's tabsequence ([Sequential Navigation Focus Order](../../concepts.md#Sequential-navigation-focus-order)). The tabsequence is obtained via [`ally.query.tabsequence`](../query/tabsequence.md) in order to follow the browser's rules of sorting the sequence.
+
+As focus can be shifted by various means, even other keyboard commands (e.g. via spatial navigation), it is also necessary to engage [`ally.maintain.disabled`](disabled.md), whenever `ally.maintain.tabFocus` is engaged.
+
+
+## Usage
+
+```js
+var handle = ally.maintain.tabFocus({
+  context: '.dialog',
+});
+
+handle.disengage();
+```
+
+### Arguments
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| context | [`<selector>`](../concepts.md#Selector) | [`documentElement`](https://developer.mozilla.org/en-US/docs/Web/API/Document/documentElement) | The scope of the DOM in which to consider the tabsequence. The first element of a collection is used. |
+
+### Returns
+
+A [`<service>`](../concepts.md#Service) interface, providing the `handle.disengage()` method to stop the service.
+
+### Throws
+
+
+## Examples
+
+* **EXAMPLE:** [`ally.maintain.tabFocus` Example](./tab-focus.example.html)
+
+
+## Changes
+
+* Added in `v#master`.
+
+
+## Notes
+
+* **WARNING:** As SVG elements cannot be focused by script in Internet Explorer and Firefox, these elements will not be part of the tabsequence, thus not reachable when `ally.maintain.tabFocus` is active.
+
+
+## Related resources
+
+* [`ally.maintain.disabled`](disabled.md) is a [service](../concepts.md#Service) disabling interactive elements in the DOM
+
+
+## Contributing
+
+* [module source](https://github.com/medialize/ally.js/blob/master/src/maintain/tab-focus.js)
+* [document source](https://github.com/medialize/ally.js/blob/master/docs/api/maintain/tab-focus.md)
+* [unit test](https://github.com/medialize/ally.js/blob/master/test/unit/maintain.tab-focus.test.js)
+

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -33,7 +33,7 @@ The Accessibility Tree (often abbreviated "AT", which may be ambiguous as it is 
 
 ## Sequential navigation focus order
 
-The Sequential Navigation Focus Order, also referred to as the Tabbing Order, is an ordered list of all keyboard focusable elements in a document. Unless elements are moved to the front of the list by specifying a positive `tabindex` attribute such as `tabindex="1"`, the tabbing order correlates to the DOM order. Users can usually navigate to the next and previous element in the list by pressing the <kbd>Tab</kbd> and <kbd>Shift Tab</kbd> keys respectively.
+The Sequential Navigation Focus Order, also referred to as the Tabbing Order or *tabsequence*, is an ordered list of all keyboard focusable elements in a document. Unless elements are moved to the front of the list by specifying a positive `tabindex` attribute such as `tabindex="1"`, the tabbing order usually correlates to the DOM order. Users can usually navigate to the next and previous element in the list by pressing the <kbd>Tab</kbd> and <kbd>Shift Tab</kbd> keys respectively.
 
 
 ## Virtual focus

--- a/docs/tutorials/accessible-dialog.md
+++ b/docs/tutorials/accessible-dialog.md
@@ -304,7 +304,6 @@ A naive implementation might listen to `keydown` events, filtering for <kbd>Tab<
 
 * focus may *not only* be shifted through <kbd>Tab</kbd>, as users of [spatial navigation](http://blog.codinghorror.com/spatial-navigation-and-opera/) will attest
 * assistive tools that provide more than sequential focus navigation (i.e. random access) may list all focusable elements of the page, including those visually behind the backdrop
-* by redirecting focus to stay within the dialog it becomes impossible to reach the browser's UI by pressing <kbd>Tab</kbd>, so we're breaking native browser behavior
 
 We could do away with the need to react to <kbd>Tab</kbd>, by simply hiding everything outside the dialog. But while setting everything to `visibility: hidden;` would certainly do the job, it would also visually hide *everything but the dialog*, rendering the backdrop useless. Most visual designers I know digress.
 
@@ -324,6 +323,7 @@ function openDialog() {
   disabledHandle = ally.maintain.disabled({
     filter: dialog,
   });
+
   // create or show the dialog
   dialog.hidden = false;
 }
@@ -335,6 +335,40 @@ function closeDialog() {
   dialog.hidden = true;
 }
 ```
+
+### Reacting to <kbd>Tab</kbd> and <kbd>Shift Tab</kbd>
+
+When the last element of the document's tabbing order has focus and the user presses the <kbd>Tab</kbd> key, focus is not wrapped around to the first element of the tabbing order, but to the browser's UI (e.g. location bar or tabs). The same is true for the first element being focused and the user pressing <kbd>Shift Tab</kbd>.
+
+This is not quite the behavior we see in the modal dialogs provided by our operating systems, where focus is always trapped within the dialog. This is a behavior keyboard users have come to expect and we need to replicate in our web UIs as well.
+
+While [`ally.maintain.disabled`](../api/maintain/disabled.md) makes sure we can't focus any other element within the document, we still need to observe the <kbd>Tab</kbd> key to make focus wrap within the dialog's tabbing order. That's what [`ally.maintain.tabFocus`](../api/maintain/tab-focus.md) is for.
+
+```js
+var dialog = document.getElementById('dialog');
+var tabHandle;
+
+function openDialog() {
+  // Make sure that Tab key controlled focus is trapped within
+  // the tabsequence of the dialog and does not reach the
+  // browser's UI, e.g. the location bar.
+  tabHandle = ally.maintain.tabFocus({
+    context: dialog,
+  });
+
+  // create or show the dialog
+  dialog.hidden = false;
+}
+
+function closeDialog() {
+  // undo trapping Tab key focus
+  tabHandle.disengage();
+  // hide or remove the dialog
+  dialog.hidden = true;
+}
+```
+
+* **NOTE:** [`ally.maintain.tabFocus`](../api/maintain/tab-focus.md) was added in version `v#master`.
 
 ### Reacting to <kbd>Enter</kbd> and <kbd>Escape</kbd>
 

--- a/docs/tutorials/dialog.example.html
+++ b/docs/tutorials/dialog.example.html
@@ -210,6 +210,7 @@
 
   // Data filled by openDialog() and later used by closeDialog()
   var keyHandle;
+  var tabHandle;
   var disabledHandle;
   var hiddenHandle;
   var focusedElementBeforeDialogOpened;
@@ -258,6 +259,13 @@
       filter: dialog,
     });
 
+    // Make sure that Tab key controlled focus is trapped within
+    // the tabsequence of the dialog and does not reach the
+    // browser's UI, e.g. the location bar.
+    tabHandle = ally.maintain.tabFocus({
+      context: dialog,
+    });
+
     // React to enter and escape keys as mandated by ARIA Practices
     keyHandle = ally.when.key({
       escape: closeDialogByKey,
@@ -289,6 +297,8 @@
   function closeDialog() {
     // undo listening to keyboard
     keyHandle.disengage();
+    // undo trapping Tab key focus
+    tabHandle.disengage();
     // undo hiding elements outside of the dialog
     hiddenHandle.disengage();
     // undo disabling elements outside of the dialog

--- a/src/is/_is.js
+++ b/src/is/_is.js
@@ -1,6 +1,7 @@
 
 // exporting modules to be included the UMD bundle
 
+import activeElement from './active-element';
 import disabled from './disabled';
 import focusRelevant from './focus-relevant';
 import focusable from './focusable';
@@ -11,6 +12,7 @@ import validArea from './valid-area';
 import validTabindex from './valid-tabindex';
 import visible from './visible';
 export default {
+  activeElement,
   disabled,
   focusRelevant,
   focusable,

--- a/src/is/active-element.js
+++ b/src/is/active-element.js
@@ -1,0 +1,27 @@
+
+// Determines if an element is the activeElement within its context, i.e. its document iFrame or ShadowHost
+
+import getShadowHost from '../get/shadow-host';
+import getDocument from '../util/get-document';
+
+export default function(element) {
+  if (element === document) {
+    element = document.documentElement;
+  }
+
+  if (!element || element.nodeType !== Node.ELEMENT_NODE) {
+    throw new TypeError('is/active-element requires an argument of type Element');
+  }
+
+  const _document = getDocument(element);
+  if (_document.activeElement === element) {
+    return true;
+  }
+
+  const shadowHost = getShadowHost({ context: element });
+  if (shadowHost && shadowHost.shadowRoot.activeElement === element) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/maintain/_maintain.js
+++ b/src/maintain/_maintain.js
@@ -3,7 +3,10 @@
 
 import disabled from './disabled';
 import hidden from './hidden';
+import tabFocus from './tab-focus';
+
 export default {
   disabled,
   hidden,
+  tabFocus,
 };

--- a/src/maintain/tab-focus.js
+++ b/src/maintain/tab-focus.js
@@ -1,0 +1,54 @@
+
+import isActiveElement from '../is/active-element';
+import queryTabsequence from '../query/tabsequence';
+import whenKey from '../when/key';
+
+export default function({ context } = {}) {
+  if (!context) {
+    context = document.documentElement;
+  }
+
+  return whenKey({
+    '?shift+tab': function(event) {
+      // we're completely taking over the Tab key handling
+      event.preventDefault();
+
+      const sequence = queryTabsequence({
+        context,
+      });
+
+      const backward = event.shiftKey;
+      const first = sequence[0];
+      const last = sequence[sequence.length - 1];
+
+      // wrap around first to last, last to first
+      const source = backward ? first : last;
+      const target = backward ? last : first;
+      if (isActiveElement(source)) {
+        target.focus();
+        return;
+      }
+
+      // find current position in tabsequence
+      let currentIndex;
+      const found = sequence.some(function(element, index) {
+        if (!isActiveElement(element)) {
+          return false;
+        }
+
+        currentIndex = index;
+        return true;
+      });
+
+      if (!found) {
+        // redirect to first as we're not in our tabsequence
+        first.focus();
+        return;
+      }
+
+      // shift focus to previous/next element in the sequence
+      const offset = backward ? -1 : 1;
+      sequence[currentIndex + offset].focus();
+    },
+  });
+}

--- a/test/functional/intern.events.test.js
+++ b/test/functional/intern.events.test.js
@@ -41,6 +41,40 @@ define([
           DOMFocusIn:second,
           keyup:second,
         ]
+        pressKeys(SHIFT TAB) input [
+          keydown:second,
+          keydown:second,
+          blur:second,
+          focusout:second,
+          DOMFocusOut:second,
+          focus:first,
+          focusin:first,
+          DOMFocusIn:first,
+          keyup:first,
+          keyup:first,
+        ]
+        pressKeys(TAB) [
+          keydown:first:9,
+          blur:first,
+          focusout:first,
+          DOMFocusOut:first,
+          focus:second,
+          focusin:second,
+          DOMFocusIn:second,
+          keyup:second:9,
+        ]
+        pressKeys(SHIFT TAB) [
+          keydown:second:16:shift,
+          keydown:second:9:shift,
+          blur:second,
+          focusout:second,
+          DOMFocusOut:second,
+          focus:first,
+          focusin:first,
+          DOMFocusIn:first,
+          keyup:first:9:shift,
+          keyup:first:16,
+        ]
 
       IE 11.0 (SauceLabs)
         click input [
@@ -72,6 +106,35 @@ define([
           blur:first,
           focus:second,
           keyup:second,
+        ]
+        pressKeys(SHIFT TAB) input [
+          keydown:second,
+          keydown:second,
+          focusout:second,
+          focusin:first,
+          blur:second,
+          focus:first,
+          keyup:first,
+          keyup:first,
+        ]
+        pressKeys(TAB) [
+          keydown:first:9,
+          focusout:first,
+          focusin:second,
+          blur:first,
+          focus:second,
+          keyup:second:9,
+        ]
+        // NOTE: event.shiftKey is not set
+        pressKeys(SHIFT TAB) (
+          keydown:second:16,
+          keydown:second:9,
+          focusout:second,
+          focusin:first,
+          blur:second,
+          focus:first,
+          keyup:first:9,
+          keyup:first:16,
         ]
     */
 
@@ -136,6 +199,64 @@ define([
           .findById('first')
             .pressKeys(keys.TAB)
             .end()
+
+          .execute('var _events = window.events.slice(0); window.events.length = 0; return _events;')
+          .then(function(events) {
+            this.skip(events.join(', '));
+          }.bind(this));
+      },
+
+      'pressKeys(SHIFT TAB) input': function() {
+        this.timeout = timeout;
+        return this.remote
+          .findById('second')
+            .click()
+            .end()
+
+          .sleep(500)
+          .execute('window.events.length = 0; return null;')
+
+          .findById('first')
+            .pressKeys([keys.SHIFT, keys.TAB])
+            .pressKeys(keys.NULL)
+            .end()
+
+          .execute('var _events = window.events.slice(0); window.events.length = 0; return _events;')
+          .then(function(events) {
+            this.skip(events.join(', '));
+          }.bind(this));
+      },
+
+      'pressKeys(TAB)': function() {
+        this.timeout = timeout;
+        return this.remote
+          .findById('first')
+            .click()
+            .end()
+
+          .sleep(500)
+          .execute('window.events.length = 0; return null;')
+
+          .pressKeys(keys.TAB)
+
+          .execute('var _events = window.events.slice(0); window.events.length = 0; return _events;')
+          .then(function(events) {
+            this.skip(events.join(', '));
+          }.bind(this));
+      },
+
+      'pressKeys(SHIFT TAB)': function() {
+        this.timeout = timeout;
+        return this.remote
+          .findById('second')
+            .click()
+            .end()
+
+          .sleep(500)
+          .execute('window.events.length = 0; return null;')
+
+          .pressKeys([keys.SHIFT, keys.TAB])
+          .pressKeys(keys.NULL)
 
           .execute('var _events = window.events.slice(0); window.events.length = 0; return _events;')
           .then(function(events) {

--- a/test/functional/maintain.tab-focus.test.js
+++ b/test/functional/maintain.tab-focus.test.js
@@ -4,7 +4,9 @@ define([
   'require',
   // https://theintern.github.io/leadfoot/keys.html
   'intern/dojo/node!leadfoot/keys',
-], function(registerSuite, expect, require, keys) {
+  // https://theintern.github.io/leadfoot/pollUntil.html
+  'intern/dojo/node!leadfoot/helpers/pollUntil',
+], function(registerSuite, expect, require, keys, pollUntil) {
 
   registerSuite(function() {
     var timeout = 120000;
@@ -29,7 +31,9 @@ define([
           .get(require.toUrl('test/pages/maintain.tab-focus.test.html'))
           .setPageLoadTimeout(timeout)
           .setFindTimeout(timeout)
-          .setExecuteAsyncTimeout(timeout);
+          .setExecuteAsyncTimeout(timeout)
+          // wait until we're really initialized
+          .then(pollUntil('return window.platform'), timeout);
       },
 
       forward: function() {

--- a/test/functional/maintain.tab-focus.test.js
+++ b/test/functional/maintain.tab-focus.test.js
@@ -8,12 +8,24 @@ define([
 
   registerSuite(function() {
     var timeout = 120000;
+    var advancesFocusOnTab = false;
 
     return {
       name: 'maintain/tab-focus',
 
       before: function() {
         return this.remote
+          .get(require.toUrl('test/pages/intern.events.test.html'))
+          .findById('first')
+            .click()
+            .end()
+          .pressKeys(keys.TAB)
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            advancesFocusOnTab = activeElementId === 'second';
+          })
+
           .get(require.toUrl('test/pages/maintain.tab-focus.test.html'))
           .setPageLoadTimeout(timeout)
           .setFindTimeout(timeout)
@@ -22,6 +34,10 @@ define([
 
       forward: function() {
         this.timeout = timeout;
+        if (!advancesFocusOnTab) {
+          this.skip('Cannot test Tab focus via WebDriver in this browser');
+        }
+
         return this.remote
           .findById('first')
             .click()
@@ -55,6 +71,10 @@ define([
       },
       backward: function() {
         this.timeout = timeout;
+        if (!advancesFocusOnTab) {
+          this.skip('Cannot test Tab focus via WebDriver in this browser');
+        }
+
         return this.remote
           .findById('third')
             .click()

--- a/test/functional/maintain.tab-focus.test.js
+++ b/test/functional/maintain.tab-focus.test.js
@@ -11,6 +11,7 @@ define([
   registerSuite(function() {
     var timeout = 120000;
     var advancesFocusOnTab = false;
+    var setsShiftKey = false;
 
     return {
       name: 'maintain/tab-focus',
@@ -26,6 +27,14 @@ define([
           .execute('return document.activeElement.id || document.activeElement.nodeName')
           .then(function(activeElementId) {
             advancesFocusOnTab = activeElementId === 'second';
+          })
+
+          .execute('window.events.length = 0')
+          .pressKeys([keys.TAB, keys.TAB])
+          .sleep(500)
+          .execute('return window.events[1]')
+          .then(function(tabKeyEvent) {
+            setsShiftKey = tabKeyEvent.indexOf(':shift') > -1;
           })
 
           .get(require.toUrl('test/pages/maintain.tab-focus.test.html'))
@@ -78,6 +87,9 @@ define([
         if (!advancesFocusOnTab) {
           this.skip('Cannot test Tab focus via WebDriver in this browser');
         }
+        if (!setsShiftKey) {
+          this.skip('Cannot test Shift Tab focus via WebDriver in this browser');
+        }
 
         return this.remote
           .findById('third')
@@ -89,8 +101,7 @@ define([
             expect(activeElementId).to.equal('third', 'initial position');
           })
 
-          .pressKeys(keys.SHIFT)
-          .pressKeys(keys.TAB)
+          .pressKeys([keys.SHIFT, keys.TAB])
           .pressKeys(keys.NULL)
           .sleep(500)
           .execute('return document.activeElement.id || document.activeElement.nodeName')
@@ -98,8 +109,7 @@ define([
             expect(activeElementId).to.equal('second', 'after first Tab');
           })
 
-          .pressKeys(keys.SHIFT)
-          .pressKeys(keys.TAB)
+          .pressKeys([keys.SHIFT, keys.TAB])
           .pressKeys(keys.NULL)
           .sleep(500)
           .execute('return document.activeElement.id || document.activeElement.nodeName')
@@ -107,8 +117,7 @@ define([
             expect(activeElementId).to.equal('first', 'after second Tab');
           })
 
-          .pressKeys(keys.SHIFT)
-          .pressKeys(keys.TAB)
+          .pressKeys([keys.SHIFT, keys.TAB])
           .pressKeys(keys.NULL)
           .sleep(500)
           .execute('return document.activeElement.id || document.activeElement.nodeName')

--- a/test/functional/maintain.tab-focus.test.js
+++ b/test/functional/maintain.tab-focus.test.js
@@ -1,0 +1,97 @@
+define([
+  'intern!object',
+  'intern/chai!expect',
+  'require',
+  // https://theintern.github.io/leadfoot/keys.html
+  'intern/dojo/node!leadfoot/keys',
+], function(registerSuite, expect, require, keys) {
+
+  registerSuite(function() {
+    var timeout = 120000;
+
+    return {
+      name: 'maintain/tab-focus',
+
+      before: function() {
+        return this.remote
+          .get(require.toUrl('test/pages/maintain.tab-focus.test.html'))
+          .setPageLoadTimeout(timeout)
+          .setFindTimeout(timeout)
+          .setExecuteAsyncTimeout(timeout);
+      },
+
+      forward: function() {
+        this.timeout = timeout;
+        return this.remote
+          .findById('first')
+            .click()
+            .end()
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            expect(activeElementId).to.equal('first', 'initial position');
+          })
+
+          .pressKeys(keys.TAB)
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            expect(activeElementId).to.equal('second', 'after first Tab');
+          })
+
+          .pressKeys(keys.TAB)
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            expect(activeElementId).to.equal('third', 'after second Tab');
+          })
+
+          .pressKeys(keys.TAB)
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            expect(activeElementId).to.equal('first', 'after third Tab');
+          });
+      },
+      backward: function() {
+        this.timeout = timeout;
+        return this.remote
+          .findById('third')
+            .click()
+            .end()
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            expect(activeElementId).to.equal('third', 'initial position');
+          })
+
+          .pressKeys(keys.SHIFT)
+          .pressKeys(keys.TAB)
+          .pressKeys(keys.NULL)
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            expect(activeElementId).to.equal('second', 'after first Tab');
+          })
+
+          .pressKeys(keys.SHIFT)
+          .pressKeys(keys.TAB)
+          .pressKeys(keys.NULL)
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            expect(activeElementId).to.equal('first', 'after second Tab');
+          })
+
+          .pressKeys(keys.SHIFT)
+          .pressKeys(keys.TAB)
+          .pressKeys(keys.NULL)
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            expect(activeElementId).to.equal('third', 'after third Tab');
+          });
+      },
+    };
+  });
+});

--- a/test/intern.js
+++ b/test/intern.js
@@ -99,6 +99,7 @@ define([
       'test/unit/is.visible.test',
       'test/unit/maintain.disabled.test',
       'test/unit/maintain.hidden.test',
+      'test/unit/maintain.tab-focus.test',
       'test/unit/observe.interaction-type.test',
       'test/unit/prototype.element.prototype.matches.test',
       'test/unit/prototype.svgelement.prototype.focus.test',
@@ -133,6 +134,7 @@ define([
     // Functional test suite(s) to run in each browser once non-functional tests are completed
     functionalSuites: [
       'test/functional/intern.events.test.js',
+      'test/functional/maintain.tab-focus.test.js',
     ],
 
     // A regular expression matching URLs to files that should not be included in code coverage analysis

--- a/test/intern.js
+++ b/test/intern.js
@@ -86,6 +86,7 @@ define([
       'test/unit/get.parents.test',
       'test/unit/get.shadow-host-parents.test',
       'test/unit/get.shadow-host.test',
+      'test/unit/is.active-element.test',
       'test/unit/is.disabled.test',
       'test/unit/is.focus-relevant.test',
       'test/unit/is.focusable.test',

--- a/test/pages/intern.events.test.html
+++ b/test/pages/intern.events.test.html
@@ -8,12 +8,26 @@
 
   <input id="first">
   <input id="second">
+  <input id="third">
 
   <script src="../../node_modules/platform/platform.js"></script>
   <script>
     window.events = [];
     function logEvent(event) {
-      events.push(event.type + ':' + (event.target.id || event.target.nodeName));
+      window.events.push(event.type + ':' + (event.target.id || event.target.nodeName));
+    }
+
+    function logKeyEvent(event) {
+      var message = [
+        event.type,
+        (event.target.id || event.target.nodeName),
+        event.keyCode,
+        event.altKey && 'alt',
+        event.ctrlKey && 'ctrl',
+        event.metaKey && 'meta',
+        event.shiftKey && 'shift',
+      ].filter(Boolean).join(':');
+      window.events.push(message);
     }
 
     [
@@ -21,10 +35,14 @@
       'mousedown', 'mouseup', 'click', 'touchstart', 'touchend',
       'pointerdown', 'pointerup', 'MSPointerDown', 'MSPointerUp',
       'input', 'beforeinput',
-      'keydown', 'keyup', 'keypress',
-
     ].forEach(function(eventName) {
       document.body.addEventListener(eventName, logEvent, true);
+    });
+
+    [
+      'keydown', 'keyup', 'keypress',
+    ].forEach(function(eventName) {
+      document.body.addEventListener(eventName, logKeyEvent, true);
     });
   </script>
 

--- a/test/pages/maintain.tab-focus.test.html
+++ b/test/pages/maintain.tab-focus.test.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Maintain Tab Focus</title>
+  <style>
+    body :focus {
+      outline: 1px solid red;
+    }
+  </style>
+</head>
+<body>
+  <h1>Maintain Tab Focus</h1>
+
+  <input id="before">
+  <input id="before-1" tabindex="1">
+
+  <div id="container">
+    <input id="second">
+    <input id="first" tabindex="1">
+    <input id="third">
+  </div>
+
+  <input id="after">
+  <input id="after-1" tabindex="1">
+
+  <script src="../../node_modules/requirejs/require.js"></script>
+  <script>
+    require.config({
+      paths: {
+        ally: '../../dist/amd',
+        // shims required by ally.js
+        'array.prototype.findindex': '../../node_modules/array.prototype.findindex/index',
+        'domtokenlist-shim': '../../node_modules/domtokenlist-shim/dist/domtokenlist',
+        'css.escape': '../../node_modules/css.escape/css.escape',
+        'platform': '../../node_modules/platform/platform'
+      }
+    });
+
+    require([
+      'ally/util/platform',
+      'ally/maintain/tab-focus',
+    ], function(platform, maintainTabFocus) {
+      window.platform = platform;
+
+      maintainTabFocus({
+        context: '#container',
+      });
+    });
+  </script>
+</body>
+</html>

--- a/test/unit/core.worker.test.js
+++ b/test/unit/core.worker.test.js
@@ -22,6 +22,7 @@ define([
       'ally.js/get/shadow-host-parents',
       'ally.js/get/shadow-host',
       'ally.js/is/disabled',
+      'ally.js/is/active-element',
       'ally.js/is/focus-relevant',
       'ally.js/is/focusable',
       'ally.js/is/native-disabled-supported',

--- a/test/unit/core.worker.test.js
+++ b/test/unit/core.worker.test.js
@@ -34,6 +34,7 @@ define([
       'ally.js/is/visible',
       'ally.js/maintain/disabled',
       'ally.js/maintain/hidden',
+      'ally.js/maintain/tab-focus',
       'ally.js/observe/interaction-type',
       'ally.js/prototype/element.prototype.matches',
       'ally.js/prototype/svgelement.prototype.focus',

--- a/test/unit/is.active-element.test.js
+++ b/test/unit/is.active-element.test.js
@@ -1,0 +1,73 @@
+define([
+  'intern!object',
+  'intern/chai!expect',
+  '../helper/fixtures/focusable.fixture',
+  '../helper/supports',
+  'ally/is/active-element',
+], function(
+  registerSuite,
+  expect,
+  focusableFixture,
+  supports,
+  isActiveElement
+) {
+
+  registerSuite(function() {
+    var fixture;
+
+    return {
+      name: 'is/active-element',
+
+      beforeEach: function() {
+        fixture = focusableFixture();
+      },
+      afterEach: function() {
+        fixture.remove();
+        fixture = null;
+      },
+
+      invalid: function() {
+        expect(function() {
+          isActiveElement(null);
+        }).to.throw(TypeError, 'is/active-element requires an argument of type Element');
+      },
+
+      simple: function() {
+        var link = document.getElementById('link');
+        var input = document.getElementById('input');
+        expect(isActiveElement(link)).to.equal(false, 'link initial');
+        expect(isActiveElement(input)).to.equal(false, 'input initial');
+
+        link.focus();
+        expect(isActiveElement(link)).to.equal(true, 'link active');
+        expect(isActiveElement(input)).to.equal(false, 'input inactive');
+
+        input.focus();
+        expect(isActiveElement(link)).to.equal(false, 'link inactive');
+        expect(isActiveElement(input)).to.equal(true, 'input active');
+      },
+
+      ShadowDOM: function() {
+        if (document.body.createShadowRoot === undefined) {
+          this.skip('Shadow DOM not supported');
+        }
+
+        var host = fixture.add([
+          /*eslint-disable indent */
+          '<div></div>',
+          /*eslint-enable indent */
+        ]).firstElementChild;
+        var root = host.createShadowRoot();
+        root.innerHTML = '<input>';
+        var input = root.firstElementChild;
+
+        expect(isActiveElement(host)).to.equal(false, 'host initial');
+        expect(isActiveElement(input)).to.equal(false, 'input initial');
+
+        input.focus();
+        expect(isActiveElement(host)).to.equal(true, 'host active');
+        expect(isActiveElement(input)).to.equal(true, 'input active');
+      },
+    };
+  });
+});

--- a/test/unit/maintain.tab-focus.test.js
+++ b/test/unit/maintain.tab-focus.test.js
@@ -1,0 +1,47 @@
+define([
+  'intern!object',
+  'intern/chai!expect',
+  '../helper/dispatch-event',
+  '../helper/fixtures/custom.fixture',
+  'ally/maintain/tab-focus',
+], function(registerSuite, expect, dispatchEvent, customFixture, maintainTabFocus) {
+
+  registerSuite(function() {
+    var fixture;
+    var handle;
+
+    return {
+      name: 'maintain/tab-focus',
+
+      beforeEach: function() {
+        fixture = customFixture([
+          /*eslint-disable indent */
+          '<div id="outer">',
+            '<div id="inner">',
+              '<input type="text" id="target">',
+            '</div>',
+          '</div>',
+          /*eslint-enable indent */
+        ]);
+      },
+      afterEach: function() {
+        // make sure a failed test cannot leave listeners behind
+        handle && handle.disengage({ force: true });
+        fixture.remove();
+        fixture = null;
+      },
+
+      lifecycle: function() {
+        expect(maintainTabFocus).to.be.a('function');
+        handle = maintainTabFocus({
+          context: fixture.root,
+        });
+
+        // cannot test this because we can't synthesize keydown events for Tab
+        // testing this in functional/maintain.tab-focus.test.js
+
+        expect(handle.disengage).to.be.a('function');
+      },
+    };
+  });
+});


### PR DESCRIPTION
covers #63 

* [x] add `ally.is/active-element` for a foreign-document and ShadowDOM-safe way of doing `document.activeElement === element`
* [x] add `ally/maintain/tabFocus` to trap <kbd>Tab</kbd> in the context element's tabsequence
