### PR TITLE
In IE11 SVG elements don't know classList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The following lists show the changes to the library grouped by domain.
 
 * upgrading to [css.escape](https://github.com/mathiasbynens/CSS.escape) v1.5.0 to work around [WebKit 149175](https://bugs.webkit.org/show_bug.cgi?id=149175)
 * upgrading to [platform.js](https://github.com/bestiejs/platform.js) v1.3.1
-* adding [domtokenlist-shim](https://github.com/jwilsson/domtokenlist) for IE9
+* adding [domtokenlist-shim](https://github.com/jwilsson/domtokenlist) for IE9 DOM `classList` and SVG `classList` in IE11
 
 #### Browser Behavior
 
@@ -68,6 +68,7 @@ The following lists show the changes to the library grouped by domain.
 * fixing [`ally.get.parents`][ally/get/parents] to resolve ancestry for `SVGElement` in Internet Explorer
 * adding [`ally.query.shadowHosts`][ally/query/shadow-hosts] to find elements hosting `ShadowRoot`s - [issue #110](https://github.com/medialize/ally.js/issues/110)
 * adding [`ally.observe.shadowMutations`][ally/observe/shadow-mutations] to register `MutationObserver`s across nested `ShadowRoot`s - [issue #110](https://github.com/medialize/ally.js/issues/110)
+* fixing [`ally.style.focusWithin`][ally/style/focus-within] to support SVG in IE10 and IE11
 
 #### Internals
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -149,7 +149,7 @@ require.config({
     'ally.js': 'node_modules/ally.js/amd',
     // provide paths to dependencies
     'array.prototype.findindex': 'node_modules/array.prototype.findindex/index',
-    'domtokenlist-shim': 'node_modules/domtokenlist-shim/dist/domtokenlist',
+    'domtokenlist-shim': 'node_modules/domtokenlist-shim',
     'css.escape': 'node_modules/css.escape/css.escape',
     'platform': 'node_modules/platform/platform',
   },

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   "dependencies": {
     "array.prototype.findindex": "^1.0.0",
     "css.escape": "^1.5.0",
-    "domtokenlist-shim": "git://github.com/rodneyrehm/domtokenlist#fix/non-browser-environment",
+    "domtokenlist-shim": "git://github.com/rodneyrehm/domtokenlist#1.2.0-alpha.1",
     "platform": "^1.3.1"
   }
 }

--- a/src/style/focus-source.js
+++ b/src/style/focus-source.js
@@ -24,7 +24,7 @@
   Alternate implementation: https://github.com/alice/modality
 */
 
-import 'domtokenlist-shim';
+import 'domtokenlist-shim/dist/domtokenlist-polyfill-umd';
 import shadowFocus from '../event/shadow-focus';
 import engageInteractionTypeObserver from '../observe/interaction-type';
 import decorateService from '../util/decorate-service';

--- a/src/style/focus-within.js
+++ b/src/style/focus-within.js
@@ -8,7 +8,7 @@
     style/focus-within()
 */
 
-import 'domtokenlist-shim';
+import 'domtokenlist-shim/dist/domtokenlist-polyfill-umd';
 import shadowFocus from '../event/shadow-focus';
 import getActiveElements from '../get/active-elements';
 import getParents from '../get/parents';

--- a/src/style/focus-within.js
+++ b/src/style/focus-within.js
@@ -53,7 +53,7 @@ function applyFocusWithinClass(active) {
       return;
     }
 
-    element.classList.remove(className);
+    element.classList && element.classList.remove(className);
   });
 
   // apply the class only to elements that do not yet have it (minimize dom action)
@@ -62,7 +62,7 @@ function applyFocusWithinClass(active) {
       return;
     }
 
-    element.classList.add(className);
+    element.classList && element.classList.add(className);
   });
 }
 

--- a/test/browserstack.js
+++ b/test/browserstack.js
@@ -48,7 +48,8 @@ define([
     // { browser: 'Safari', browser_version: '7.1', os: 'OS X', os_version: 'Mavericks', platform: 'MAC', browserName: 'Safari 7' },
     // { browser: 'Safari', browser_version: '6.2', os: 'OS X', os_version: 'Mountain Lion', platform: 'MAC', browserName: 'Safari 6' },
 
-    { browserName: 'iPhone', platform: 'MAC', device: 'iPhone 6S' },
+    // Disabled because tests are flaky and BrowserStack-Support claims Intern is the culprit
+    // { browserName: 'iPhone', platform: 'MAC', device: 'iPhone 6S' },
   ];
   /*eslint-enable camelcase */
 

--- a/test/functional/style.focus-within.test.js
+++ b/test/functional/style.focus-within.test.js
@@ -1,0 +1,90 @@
+define([
+  'intern!object',
+  'intern/chai!expect',
+  'require',
+  // https://theintern.github.io/leadfoot/keys.html
+  'intern/dojo/node!leadfoot/keys',
+  // https://theintern.github.io/leadfoot/pollUntil.html
+  'intern/dojo/node!leadfoot/helpers/pollUntil',
+], function(registerSuite, expect, require, keys, pollUntil) {
+
+  registerSuite(function() {
+    var timeout = 120000;
+    var advancesFocusOnTab = false;
+
+    // Since we cannot .focus() SVG content in Firefox and Internet Explorer,
+    // we need to run this unit test as a functional test, so we can emit
+    // proper TAB key to make the browser shift focus to the SVG element
+
+    return {
+      name: 'style/focus-within',
+
+      before: function() {
+        return this.remote
+          .get(require.toUrl('test/pages/intern.events.test.html'))
+          .findById('first')
+            .click()
+            .end()
+          .pressKeys(keys.TAB)
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            advancesFocusOnTab = activeElementId === 'second';
+          })
+
+          .get(require.toUrl('test/pages/style.focus-within.test.html'))
+          .setPageLoadTimeout(timeout)
+          .setFindTimeout(timeout)
+          .setExecuteAsyncTimeout(timeout)
+          // wait until we're really initialized
+          .then(pollUntil('return window.platform'), timeout);
+      },
+
+      'follow focus into SVG': function() {
+        this.timeout = timeout;
+        if (!advancesFocusOnTab) {
+          this.skip('Cannot test Tab focus via WebDriver in this browser');
+        }
+
+        return this.remote
+          .findById('before')
+            .click()
+            .end()
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            expect(activeElementId).to.equal('before', 'initial position');
+          })
+          .execute('return [].map.call(document.querySelectorAll(".ally-focus-within"), function(e) { return e.id || e.nodeName })')
+          .then(function(elements) {
+            var expected = ['HTML', 'BODY', 'before'];
+            expect(elements).to.deep.equal(expected, '.ally-focus-within after first Tab');
+          })
+
+          .pressKeys(keys.TAB)
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            expect(activeElementId).to.equal('svg-link', 'activeElement after first Tab');
+          })
+          .execute('return [].map.call(document.querySelectorAll(".ally-focus-within"), function(e) { return e.id || e.nodeName })')
+          .then(function(elements) {
+            var expected = ['HTML', 'BODY', 'container', 'svg', 'svg-link'];
+            expect(elements).to.deep.equal(expected, '.ally-focus-within after first Tab');
+          })
+
+          .pressKeys(keys.TAB)
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            expect(activeElementId).to.equal('after', 'after second Tab');
+          })
+          .execute('return [].map.call(document.querySelectorAll(".ally-focus-within"), function(e) { return e.id || e.nodeName })')
+          .then(function(elements) {
+            var expected = ['HTML', 'BODY', 'container', 'after'];
+            expect(elements).to.deep.equal(expected, '.ally-focus-within after second Tab');
+          });
+      },
+    };
+  });
+});

--- a/test/functional/style.focus-within.test.js
+++ b/test/functional/style.focus-within.test.js
@@ -11,6 +11,7 @@ define([
   registerSuite(function() {
     var timeout = 120000;
     var advancesFocusOnTab = false;
+    var advancesFocusToLinks = false;
 
     // Since we cannot .focus() SVG content in Firefox and Internet Explorer,
     // we need to run this unit test as a functional test, so we can emit
@@ -32,6 +33,16 @@ define([
             advancesFocusOnTab = activeElementId === 'second';
           })
 
+          .findById('second')
+            .click()
+            .end()
+          .pressKeys(keys.TAB)
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            advancesFocusToLinks = activeElementId === 'third';
+          })
+
           .get(require.toUrl('test/pages/style.focus-within.test.html'))
           .setPageLoadTimeout(timeout)
           .setFindTimeout(timeout)
@@ -44,6 +55,10 @@ define([
         this.timeout = timeout;
         if (!advancesFocusOnTab) {
           this.skip('Cannot test Tab focus via WebDriver in this browser');
+        }
+
+        if (!advancesFocusToLinks) {
+          this.skip('Cannot test Tab to link focus via WebDriver in this browser');
         }
 
         return this.remote

--- a/test/helper/worker.js
+++ b/test/helper/worker.js
@@ -7,7 +7,7 @@ require.config({
     'ally.js': '../../dist/amd',
     // provide paths to dependencies
     'array.prototype.findindex': '../../node_modules/array.prototype.findindex/index',
-    'domtokenlist-shim': '../../node_modules/domtokenlist-shim/dist/domtokenlist',
+    'domtokenlist-shim': '../../node_modules/domtokenlist-shim',
     'css.escape': '../../node_modules/css.escape/css.escape',
     platform: '../../node_modules/platform/platform',
   },

--- a/test/intern.js
+++ b/test/intern.js
@@ -149,6 +149,7 @@ define([
       'test/functional/fix.pointer-focus-input.test.js',
       'test/functional/fix.pointer-focus-parent.test.js',
       'test/functional/observe.interaction-type.test.js',
+      'test/functional/style.focus-within.test.js',
     ],
 
     // A regular expression matching URLs to files that should not be included in code coverage analysis

--- a/test/intern.js
+++ b/test/intern.js
@@ -35,7 +35,7 @@ define([
       paths: {
         'array.prototype.findindex': 'node_modules/array.prototype.findindex/index',
         'css.escape': 'node_modules/css.escape/css.escape',
-        'domtokenlist-shim': 'node_modules/domtokenlist-shim/dist/domtokenlist',
+        'domtokenlist-shim': 'node_modules/domtokenlist-shim',
         platform: 'node_modules/platform/platform',
       },
     },

--- a/test/pages/fix.pointer-focus-children.test.html
+++ b/test/pages/fix.pointer-focus-children.test.html
@@ -111,7 +111,7 @@
         ally: '../../dist/amd',
         // shims required by ally.js
         'array.prototype.findindex': '../../node_modules/array.prototype.findindex/index',
-        'domtokenlist-shim': '../../node_modules/domtokenlist-shim/dist/domtokenlist',
+        'domtokenlist-shim': '../../node_modules/domtokenlist-shim',
         'css.escape': '../../node_modules/css.escape/css.escape',
         'platform': '../../node_modules/platform/platform',
       }

--- a/test/pages/fix.pointer-focus-input.test.html
+++ b/test/pages/fix.pointer-focus-input.test.html
@@ -102,7 +102,7 @@
         ally: '../../dist/amd',
         // shims required by ally.js
         'array.prototype.findindex': '../../node_modules/array.prototype.findindex/index',
-        'domtokenlist-shim': '../../node_modules/domtokenlist-shim/dist/domtokenlist',
+        'domtokenlist-shim': '../../node_modules/domtokenlist-shim',
         'css.escape': '../../node_modules/css.escape/css.escape',
         'platform': '../../node_modules/platform/platform',
       }

--- a/test/pages/fix.pointer-focus-parent.test.html
+++ b/test/pages/fix.pointer-focus-parent.test.html
@@ -48,7 +48,7 @@
         ally: '../../dist/amd',
         // shims required by ally.js
         'array.prototype.findindex': '../../node_modules/array.prototype.findindex/index',
-        'domtokenlist-shim': '../../node_modules/domtokenlist-shim/dist/domtokenlist',
+        'domtokenlist-shim': '../../node_modules/domtokenlist-shim',
         'css.escape': '../../node_modules/css.escape/css.escape',
         'platform': '../../node_modules/platform/platform',
       }

--- a/test/pages/intern.events.test.html
+++ b/test/pages/intern.events.test.html
@@ -8,7 +8,8 @@
 
   <input id="first">
   <input id="second">
-  <input id="third">
+  <a href="#void" id="third">test</a>
+  <input id="fourth">
 
   <script src="../../node_modules/platform/platform.js"></script>
   <script>

--- a/test/pages/maintain.tab-focus.test.html
+++ b/test/pages/maintain.tab-focus.test.html
@@ -31,7 +31,7 @@
         ally: '../../dist/amd',
         // shims required by ally.js
         'array.prototype.findindex': '../../node_modules/array.prototype.findindex/index',
-        'domtokenlist-shim': '../../node_modules/domtokenlist-shim/dist/domtokenlist',
+        'domtokenlist-shim': '../../node_modules/domtokenlist-shim',
         'css.escape': '../../node_modules/css.escape/css.escape',
         'platform': '../../node_modules/platform/platform'
       }

--- a/test/pages/observe.interaction-type.test.html
+++ b/test/pages/observe.interaction-type.test.html
@@ -14,7 +14,7 @@
         ally: '../../dist/amd',
         // shims required by ally.js
         'array.prototype.findindex': '../../node_modules/array.prototype.findindex/index',
-        'domtokenlist-shim': '../../node_modules/domtokenlist-shim/dist/domtokenlist',
+        'domtokenlist-shim': '../../node_modules/domtokenlist-shim',
         'css.escape': '../../node_modules/css.escape/css.escape',
         'platform': '../../node_modules/platform/platform'
       }

--- a/test/pages/style.focus-within.test.html
+++ b/test/pages/style.focus-within.test.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Style focus-within</title>
+  <style>
+    body .ally-focus-within {
+      outline: 1px solid blue;
+    }
+    body :focus {
+      outline: 1px solid red;
+    }
+  </style>
+</head>
+<body>
+  <h1>Style focus-within</h1>
+
+  <input id="before">
+
+  <div id="container">
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="svg" focusable="false">
+      <a xlink:href="#void" id="svg-link">
+        <text x="10" y="20" id="svg-link-text">text</text>
+      </a>
+    </svg>
+
+    <input id="after">
+  </div>
+
+  <script src="../../node_modules/requirejs/require.js"></script>
+  <script>
+    require.config({
+      paths: {
+        ally: '../../dist/amd',
+        // shims required by ally.js
+        'array.prototype.findindex': '../../node_modules/array.prototype.findindex/index',
+        'domtokenlist-shim': '../../node_modules/domtokenlist-shim',
+        'css.escape': '../../node_modules/css.escape/css.escape',
+        'platform': '../../node_modules/platform/platform'
+      }
+    });
+
+    require([
+      'ally/util/platform',
+      'ally/style/focus-within',
+    ], function(platform, styleFocusWithin) {
+      window.platform = platform;
+
+      styleFocusWithin();
+    });
+  </script>
+</body>
+</html>

--- a/tests/focusable/focusable.js
+++ b/tests/focusable/focusable.js
@@ -5,7 +5,7 @@ require.config({
     // shims required by ally.js
     'array.prototype.findindex': '../../node_modules/array.prototype.findindex/index',
     'css.escape': '../../node_modules/css.escape/css.escape',
-    'domtokenlist-shim': '../../node_modules/domtokenlist-shim/dist/domtokenlist',
+    'domtokenlist-shim': '../../node_modules/domtokenlist-shim',
     'es6-promise': '../../node_modules/es6-promise/dist/es6-promise',
     // stuff used for testing and co
     platform: '../../node_modules/platform/platform',


### PR DESCRIPTION
Fixes an Issue with `style/focus-within` and SVG content in IE11. IE11 does not know `classList` on SVG content. see jwilsson/domtokenlist#14