### PR TITLE
test(browserstack): re-enable Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "glob-cli": "^1.0.0",
     "handlebars": "^4.0.5",
     "husky": "^0.11.1",
-    "intern": "rodneyrehm/intern#fix/proxy-mimetypes",
+    "intern": "theintern/intern#75c1472",
     "jquery": "^2.1.4",
     "jquery-ui": "git://github.com/jquery/jquery-ui.git#1.11.4",
     "jsbin-sync": "^0.3.1",

--- a/test/browserstack.js
+++ b/test/browserstack.js
@@ -42,11 +42,42 @@ define([
       firefox_profile: firefoxProfileWebcomponents,
     },
 
-    // Disabled because Intern and SafariDriver and BrowserStack aren't playing nice
-    // { browser: 'Safari', browser_version: '9.0', os: 'OS X', os_version: 'El Capitan', platform: 'MAC', browserName: 'Safari 9' },
-    // { browser: 'Safari', browser_version: '8', os: 'OS X', os_version: 'Yosemite', platform: 'MAC', browserName: 'Safari 8' },
-    // { browser: 'Safari', browser_version: '7.1', os: 'OS X', os_version: 'Mavericks', platform: 'MAC', browserName: 'Safari 7' },
-    // { browser: 'Safari', browser_version: '6.2', os: 'OS X', os_version: 'Mountain Lion', platform: 'MAC', browserName: 'Safari 6' },
+    {
+      browser: 'Safari',
+      browser_version: '9.0',
+      os: 'OS X',
+      os_version: 'El Capitan',
+      platform: 'MAC',
+      browserName: 'Safari 9',
+      'browserstack.safari.driver': '2.48',
+    },
+    {
+      browser: 'Safari',
+      browser_version: '8',
+      os: 'OS X',
+      os_version: 'Yosemite',
+      platform: 'MAC',
+      browserName: 'Safari 8',
+      'browserstack.safari.driver': '2.48',
+    },
+    {
+      browser: 'Safari',
+      browser_version: '7.1',
+      os: 'OS X',
+      os_version: 'Mavericks',
+      platform: 'MAC',
+      browserName: 'Safari 7',
+      'browserstack.safari.driver': '2.48',
+    },
+    {
+      browser: 'Safari',
+      browser_version: '6.2',
+      os: 'OS X',
+      os_version: 'Mountain Lion',
+      platform: 'MAC',
+      browserName: 'Safari 6',
+      'browserstack.safari.driver': '2.48',
+    },
 
     // Disabled because tests are flaky and BrowserStack-Support claims Intern is the culprit
     // { browserName: 'iPhone', platform: 'MAC', device: 'iPhone 6S' },

--- a/test/functional/maintain.tab-focus.test.js
+++ b/test/functional/maintain.tab-focus.test.js
@@ -42,7 +42,7 @@ define([
           .setFindTimeout(timeout)
           .setExecuteAsyncTimeout(timeout)
           // wait until we're really initialized
-          .then(pollUntil('return window.platform'), timeout);
+          .then(pollUntil('return window.platform'));
       },
 
       forward: function() {

--- a/test/functional/observe.interaction-type.test.js
+++ b/test/functional/observe.interaction-type.test.js
@@ -21,7 +21,7 @@ define([
           .setFindTimeout(timeout)
           .setExecuteAsyncTimeout(timeout)
           // wait until we're really initialized
-          .then(pollUntil('return window.platform'), timeout);
+          .then(pollUntil('return window.platform'));
       },
 
       pointer: function() {

--- a/test/functional/style.focus-within.test.js
+++ b/test/functional/style.focus-within.test.js
@@ -48,7 +48,7 @@ define([
           .setFindTimeout(timeout)
           .setExecuteAsyncTimeout(timeout)
           // wait until we're really initialized
-          .then(pollUntil('return window.platform'), timeout);
+          .then(pollUntil('return window.platform'));
       },
 
       'follow focus into SVG': function() {


### PR DESCRIPTION
Currently the automated tests for Safari 6, 7, 8, 9 and iOS 9 are disabled because of problems somwhere in between Intern, BrowserStack, SafariDriver / ios-driver. This PR enables these tests. They are expected to fail until the problems are resolved.

BrowserStack is informed of the problems with Safari and they are investigating. The iOS issue seems to lie with Intern, as the BrowserStack support reproduced the flakynes™ while running the iOS Simulator and Intern locally. I've not been able to get a local setup running.

I hope these issues can be resolved in the next few days. If not, we'll release 1.1.0 anyway. In that case the test suites will be executed in each individual browser directly (avoiding WebDriver).