### PR TITLE
fix ally.element.disabled to disable SVG links in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * fixing `supports/focus-in-hiden-iframe` to avoid `document.write()` - [issue #126](https://github.com/medialize/ally.js/issues/126)
 * adding [`ally.element.focus`][ally/element/focus] - [issue #121](https://github.com/medialize/ally.js/issues/121)
 * removing `svgelement.prototype.focus` as this should be covered more elegantly by [`ally.element.focus`][ally/element/focus]
+* fixing [`ally.element.disabled`][ally/element/disabled] to remove SVG links from the document's tabbing order in Firefox
 
 
 ## 1.1.0 - Reality Strikes Back

--- a/docs/api/element/disabled.md
+++ b/docs/api/element/disabled.md
@@ -59,6 +59,11 @@ var isDisabled = ally.element.disabled(element);
 * **EXAMPLE:** [`ally.element.disabled` Example](./disabled.example.html)
 
 
+## Changes
+
+* As of `v#master` `<a xlink:href="…">` is demoted to `<a>` in order to remove the element from the document's tabbing order in Firefox.
+
+
 ## Notes
 
 * **WARNING:** Internet Explorer 10 - 11 leave a few disabled elements focusable and thus editable to the mouse, but not keyboard focusable [Trident 962368](https://connect.microsoft.com/IE/feedbackdetail/view/962368), [Trident 817488](https://connect.microsoft.com/IE/feedbackdetail/view/817488) (ally.js does not fix that). One can prevent this wrong behavior by adding `:disabled { pointer-events: none; }`.

--- a/src/element/disabled.supports.js
+++ b/src/element/disabled.supports.js
@@ -1,0 +1,11 @@
+
+import memorizeResult from '../supports/memorize-result';
+import canFocusSvgFocusableAttribute from '../supports/focus-svg-focusable-attribute';
+import canFocusSvgTabindexAttribute from '../supports/focus-svg-tabindex-attribute';
+
+export default memorizeResult(function() {
+  return {
+    canFocusSvgFocusableAttribute: canFocusSvgFocusableAttribute(),
+    canFocusSvgTabindexAttribute: canFocusSvgTabindexAttribute(),
+  };
+});

--- a/src/util/toggle-attribute.js
+++ b/src/util/toggle-attribute.js
@@ -1,0 +1,26 @@
+
+// helper to turn
+//  <div some-attribute="original">
+// into
+//  <div data-cached-some-attribute="original">
+// and back
+
+export default function({element, attribute}) {
+  const temporaryAttribute = 'data-cached-' + attribute;
+  const temporaryAttributeValue = element.getAttribute(temporaryAttribute);
+
+  if (temporaryAttributeValue === null) {
+    const _value = element.getAttribute(attribute);
+    if (_value === null) {
+      // can't remove what's not there
+      return;
+    }
+
+    element.setAttribute(temporaryAttribute, _value || '');
+    element.removeAttribute(attribute);
+  } else {
+    const _value = element.getAttribute(temporaryAttribute);
+    element.removeAttribute(temporaryAttribute);
+    element.setAttribute(attribute, _value);
+  }
+}

--- a/test/browser.js
+++ b/test/browser.js
@@ -5,6 +5,10 @@ define([
   // make sure to start the proxy, but not run the tests when
   // this config is used with the intern-runner CLI
   config.proxyOnly = true;
+  // disable instrumentation to get clean files for debugging
+  // and prevent the Proxy's internal cache for instrumented
+  // files from serving changed content
+  config.excludeInstrumentation = true;
 
   delete config.reporters;
 

--- a/test/functional/element.disabled.test.js
+++ b/test/functional/element.disabled.test.js
@@ -1,0 +1,65 @@
+define([
+  'intern!object',
+  'intern/chai!expect',
+  'require',
+  // https://theintern.github.io/leadfoot/keys.html
+  'intern/dojo/node!leadfoot/keys',
+  // https://theintern.github.io/leadfoot/pollUntil.html
+  'intern/dojo/node!leadfoot/helpers/pollUntil',
+], function(registerSuite, expect, require, keys, pollUntil) {
+
+  registerSuite(function() {
+    var timeout = 120000;
+    var advancesFocusOnTab = false;
+
+    return {
+      name: 'element/disabled',
+
+      before: function() {
+        return this.remote
+          .get(require.toUrl('test/pages/intern.events.test.html'))
+          .findById('first')
+            .click()
+            .end()
+          .pressKeys(keys.TAB)
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            advancesFocusOnTab = activeElementId === 'second';
+          })
+
+          .get(require.toUrl('test/pages/element.disabled.test.html'))
+          .setPageLoadTimeout(timeout)
+          .setFindTimeout(timeout)
+          .setExecuteAsyncTimeout(timeout)
+          // wait until we're really initialized
+          .then(pollUntil('return window.platform'));
+      },
+
+      'skips disabled elements': function() {
+        this.timeout = timeout;
+        if (!advancesFocusOnTab) {
+          this.skip('Cannot test Tab focus via WebDriver in this browser');
+        }
+
+        return this.remote
+          .findById('before')
+            .click()
+            .end()
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            expect(activeElementId).to.equal('before', 'initial position');
+          })
+
+          .pressKeys(keys.TAB)
+          .sleep(500)
+          .execute('return document.activeElement.id || document.activeElement.nodeName')
+          .then(function(activeElementId) {
+            expect(activeElementId).to.equal('after', 'after first Tab');
+          });
+      },
+
+    };
+  });
+});

--- a/test/intern.js
+++ b/test/intern.js
@@ -146,10 +146,11 @@ define([
     // Functional test suite(s) to run in each browser once non-functional tests are completed
     functionalSuites: [
       'test/functional/intern.events.test.js',
-      'test/functional/maintain.tab-focus.test.js',
+      'test/functional/element.disabled.test.js',
       'test/functional/fix.pointer-focus-children.test.js',
       'test/functional/fix.pointer-focus-input.test.js',
       'test/functional/fix.pointer-focus-parent.test.js',
+      'test/functional/maintain.tab-focus.test.js',
       'test/functional/observe.interaction-type.test.js',
       'test/functional/style.focus-within.test.js',
     ],

--- a/test/pages/element.disabled.test.html
+++ b/test/pages/element.disabled.test.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Element Disabled</title>
+  <style>
+    body :focus {
+      outline: 1px solid red;
+    }
+  </style>
+</head>
+<body>
+  <h1>Element Disabled</h1>
+
+  <input id="before">
+
+  <div id="container">
+    <div id="inert-div">a</div>
+    <div tabindex="-1" id="tabindex--1">a</div>
+    <div tabindex="0" id="tabindex-0">a</div>
+    <div tabindex="1" id="tabindex-1">a</div>
+
+    <a href="#" id="link">yep</a>
+
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="svg">
+      <a xlink:href="#void" id="svg-link">
+        <text x="10" y="20" id="svg-link-text">text</text>
+      </a>
+    </svg>
+
+    <video id="video" poster="../../test/media/test.poster.png" controls>
+      <source src="../../test/media/test.mp4"></source>
+      <source src="../../test/media/test.webm"></source>
+      <source src="../../test/media/test.ogv"></source>
+      <p>no &lt;video&gt; support</p>
+    </video>
+
+    <audio id="audio" controls>
+      <source src="../../test/media/test.mp3"></source>
+      <source src="../../test/media/test.ogg"></source>
+      <p>no &lt;audio&gt; support</p>
+    </audio>
+  </div>
+
+  <input id="after">
+
+  <script src="../../node_modules/requirejs/require.js"></script>
+  <script>
+    require.config({
+      paths: {
+        ally: '../../dist/amd',
+        // shims required by ally.js
+        'array.prototype.findindex': '../../node_modules/array.prototype.findindex/index',
+        'domtokenlist-shim': '../../node_modules/domtokenlist-shim',
+        'css.escape': '../../node_modules/css.escape/css.escape',
+        'platform': '../../node_modules/platform/platform'
+      }
+    });
+
+    require([
+      'ally/util/platform',
+      'ally/query/focusable',
+      'ally/element/disabled',
+    ], function(platform, queryFocusable, elementDisabled) {
+      window.platform = platform;
+
+      queryFocusable({
+        context: '#container',
+        strategy: 'all',
+      }).forEach(function(element) {
+        elementDisabled(element, true);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/test/unit/element.disabled.test.js
+++ b/test/unit/element.disabled.test.js
@@ -198,7 +198,8 @@ define([
         expect(element.hasAttribute('focusable')).to.equal(false, 'before disable');
 
         elementDisabled(element, true);
-        expect(element.getAttribute('focusable')).to.equal('false', 'after disable');
+        var expected = supports.canFocusSvgFocusableAttribute ? 'false' : null;
+        expect(element.getAttribute('focusable')).to.equal(expected, 'after disable');
 
         elementDisabled(element, false);
         expect(element.hasAttribute('focusable')).to.equal(false, 'after disable undo');
@@ -208,7 +209,8 @@ define([
         expect(element.getAttribute('focusable')).to.equal('true', 'before disable');
 
         elementDisabled(element, true);
-        expect(element.getAttribute('focusable')).to.equal('false', 'after disable');
+        var expected = supports.canFocusSvgFocusableAttribute ? 'false' : 'true';
+        expect(element.getAttribute('focusable')).to.equal(expected, 'after disable');
 
         elementDisabled(element, false);
         expect(element.getAttribute('focusable')).to.equal('true', 'after disable undo');
@@ -218,10 +220,24 @@ define([
         expect(element.hasAttribute('focusable')).to.equal(false, 'before disable');
 
         elementDisabled(element, true);
-        expect(element.getAttribute('focusable')).to.equal('false', 'after disable');
+        var expected = supports.canFocusSvgFocusableAttribute ? 'false' : null;
+        expect(element.getAttribute('focusable')).to.equal(expected, 'after disable');
 
         elementDisabled(element, false);
         expect(element.hasAttribute('focusable')).to.equal(false, 'after disable undo');
+      },
+      'disable removes SVG link': function() {
+        var element = document.getElementById('svg-link');
+
+        var initialValue = element.getAttribute('xlink:href');
+        expect(element.hasAttribute('xlink:href')).to.equal(true, 'before disable');
+
+        elementDisabled(element, true);
+        var expected = supports.canFocusSvgFocusableAttribute || supports.canFocusSvgTabindexAttribute;
+        expect(element.hasAttribute('xlink:href')).to.equal(expected, 'after disable');
+
+        elementDisabled(element, false);
+        expect(element.getAttribute('xlink:href')).to.equal(initialValue, 'after disable undo');
       },
 
     };


### PR DESCRIPTION
Since Firefox does not support the `tabindex` and `focusable` attributes on SVG content, links `<a xlink:href="...">` were not properly removed from the tabbing order. While not availble to the mouse, one could <kbd>Tab</kbd> to these links.

This PR fixes that problem by removing (and restoring) the `xlink:href` attribute.