### PR TITLE
Fixes a crash if document.body is not ready yet

### DIFF
--- a/src/event/shadow-focus.js
+++ b/src/event/shadow-focus.js
@@ -19,7 +19,7 @@ import decorateService from '../util/decorate-service';
 let engage;
 let disengage;
 
-if (typeof document === 'undefined' || !document.body.createShadowRoot) {
+if (typeof document === 'undefined' || !document.documentElement.createShadowRoot) {
   // no need to initialize any of this if we don't have Shadow DOM available
   engage = disengage = function() {};
 } else {


### PR DESCRIPTION
Ally tries to access `document.body` to soon.
This fix uses `document.documentElement` which is the "html" element.