### PR TITLE
feat(focus-source): Added handle.unlock

### DIFF
--- a/docs/api/style/focus-source.md
+++ b/docs/api/style/focus-source.md
@@ -97,11 +97,15 @@ The `handle.current()` method does not accept any arguments and returns one of t
 
 ### handle.used(`<string>`)
 
-The `handle.used()` method accepts one string argument and returns `true` if it matches the current interaction type.
+The `handle.used()` method accepts one string argument and returns `true` if that interaction type has ever been used before.
 
-### handle.lock(`<string>`)
+### handle.lock(`<string>|<boolean>`)
 
 The `handle.lock()` method accepts one string argument and sets that as the interaction type for all subsequent `handle.current()` invocations. The lock is reset when `false` is passed.
+
+### handle.unlock()
+
+The `handle.unlock()` method releases the focus-source lock.
 
 
 ## Examples

--- a/src/style/focus-source.js
+++ b/src/style/focus-source.js
@@ -84,6 +84,10 @@ function lockFocusSource(source) {
   lock = source;
 }
 
+function unlockFocusSource() {
+  lock = false;
+}
+
 function disengage() {
   // clear dom state
   handleFocusEvent({type: blurEventName});
@@ -118,6 +122,7 @@ function engage() {
     used: getUsedFocusSource,
     current: getCurrentFocusSource,
     lock: lockFocusSource,
+    unlock: unlockFocusSource,
   };
 }
 

--- a/test/unit/style.focus-source.test.js
+++ b/test/unit/style.focus-source.test.js
@@ -122,6 +122,22 @@ define(function(require) {
         fixture.input.outer.focus();
         expect(handle.current()).to.equal('key', 'current() after third focus shift');
       },
+      'unlock()': function() {
+        handle = styleFocusSource();
+
+        dispatchEvent.mouse(document.documentElement, 'mousedown', {});
+        fixture.input.outer.focus();
+        dispatchEvent.mouse(document.documentElement, 'mouseup', {});
+
+        expect(handle.current()).to.equal('pointer', 'current() after focus shift');
+
+        handle.lock('key');
+        fixture.input.after.focus();
+        expect(handle.current()).to.equal('key', 'current() after second focus shift');
+        handle.unlock();
+        fixture.input.outer.focus();
+        expect(handle.current()).to.equal('pointer', 'current() after third focus shift');
+      },
     };
   });
 });


### PR DESCRIPTION
Introduces a new method for focus-source: `handle.unlock()`.

For details please see #150
