### PR TITLE
Fix/compare document position fails to work correctly in shadow dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "build:umd": "npm-run-all --sequential build:umd:bundle build:umd:min build:umd:clean",
     "build:umd:bundle": "browserify dist/src/ally.js --debug --standalone ally --transform rollupify --transform [ babelify --presets [ es2015 ] ] | exorcist dist/ally.js.map > dist/ally.js",
     "build:umd:clean": "rm dist/ally.js dist/ally.js.map",
-    "build:umd:min": "uglifyjs dist/ally.js --in-source-map dist/ally.js.map --source-map dist/ally.min.js.map --source-map-url ally.min.js.map --preamble \"/*! ${npm_package_name} - v${npm_package_version} - ${npm_package_homepage} - ${npm_package_license} License */\" --mangle --compress --output dist/ally.min.js",
+    "build:umd:min": "uglifyjs dist/ally.js --in-source-map dist/ally.js.map --source-map --source-map-url --preamble \"/*! ${npm_package_name} - v${npm_package_version} - ${npm_package_homepage} - ${npm_package_license} License */\" --mangle --compress --output dist/ally.min.js",
     "build:common": "babel --no-babelrc --presets es2015 --plugins add-module-exports --source-maps --out-dir dist/common dist/src",
     "build:amd": "babel --no-babelrc --presets es2015 --plugins add-module-exports,transform-es2015-modules-umd --source-maps --out-dir dist/amd dist/src",
     "build:esm": "babel --source-maps --out-dir dist/esm dist/src",

--- a/src/util/compare-position.js
+++ b/src/util/compare-position.js
@@ -9,19 +9,29 @@
     listOfElements.some(isChildOf)
 */
 
+import {getShadowParent} from './get-shadow-parent';
+
 export function getParentComparator({parent, element, includeSelf} = {}) {
   if (parent) {
     return function isChildOf(node) {
+      const shadowParent = getShadowParent(node);
       return Boolean(
-        includeSelf && node === parent
+        (includeSelf && node === parent
+          || shadowParent === parent)
         || parent.compareDocumentPosition(node) & Node.DOCUMENT_POSITION_CONTAINED_BY
+        || (shadowParent
+          && parent.compareDocumentPosition(shadowParent) & Node.DOCUMENT_POSITION_CONTAINED_BY)
       );
     };
   } else if (element) {
     return function isParentOf(node) {
+      const shadowParent = getShadowParent(element);
       return Boolean(
-        includeSelf && element === node
+        (includeSelf && element === node
+          || shadowParent === node)
         || node.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_CONTAINED_BY
+        || (shadowParent
+          && node.compareDocumentPosition(shadowParent) & Node.DOCUMENT_POSITION_CONTAINED_BY)
       );
     };
   }

--- a/src/util/get-shadow-parent.js
+++ b/src/util/get-shadow-parent.js
@@ -1,0 +1,13 @@
+/*
+  Get the shadow root host element if the node passed in is in the shadow root
+  USAGE:
+    var shadowParent = getShadowParent(someNode)
+*/
+export function getShadowParent(node) {
+  for (; node; node = node.parentNode) {
+    if (node.toString() === '[object ShadowRoot]') {
+      return node.host;
+    }
+  }
+  return null;
+}

--- a/test/unit/maintain.disabled.test.js
+++ b/test/unit/maintain.disabled.test.js
@@ -188,6 +188,13 @@ define(function(require) {
         expect(fixture.input.after.disabled).to.equal(false, 'not disabled within filter');
         expect(fixture.input.first.disabled).to.equal(false, 'not disabled within Shadow Root');
       });
+
+      bdd.it('should not disable filtered shadowed elements', function() {
+        handle = maintainDisabled({
+          filter: '#first-shadow-host',
+        });
+        expect(fixture.input.first.disabled).to.equal(false, 'not disabled within Shadow Root');
+      });
     });
 
     bdd.describe('for DOM Mutation', function() {


### PR DESCRIPTION
Fixes #172 
Added a unit test to capture scenario where filtered shadow root elements were being disabled erroneously.
Enhanced compare position to work correctly for shadow root elements